### PR TITLE
Cache AuthenticateResult to workaround AuthenticateAsync always using old/stale value

### DIFF
--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
@@ -32,7 +32,8 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
 
         services.TryAddTransient<IUserTokenManagementService, UserAccessAccessTokenManagementService>();
         services.TryAddTransient<IOpenIdConnectConfigurationService, OpenIdConnectConfigurationService>();
-        services.TryAddTransient<IUserTokenStore, AuthenticationSessionUserAccessTokenStore>();
+        // scoped since it will be caching per-request authentication results
+        services.TryAddScoped<IUserTokenStore, AuthenticationSessionUserAccessTokenStore>();
         services.TryAddSingleton<IUserTokenRequestSynchronization, UserTokenRequestSynchronization>();
         services.TryAddTransient<IUserTokenEndpointService, UserTokenEndpointService>();
         


### PR DESCRIPTION
Fixes: https://github.com/DuendeSoftware/Duende.AccessTokenManagement/issues/6