### PR TITLE
Unhandled exception when OIDC Provider has no revocation-endpoint

### DIFF
--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
@@ -73,7 +73,7 @@ public class OpenIdConnectConfigurationService : IOpenIdConnectConfigurationServ
             
             Authority = options.Authority,
             TokenEndpoint = configuration.TokenEndpoint,
-            RevocationEndpoint = configuration.AdditionalData[OidcConstants.Discovery.RevocationEndpoint].ToString(),
+            RevocationEndpoint = configuration.AdditionalData.TryGetValue(OidcConstants.Discovery.RevocationEndpoint, out var value) ? value?.ToString() : null,
             
             ClientId = options.ClientId,
             ClientSecret = options.ClientSecret,

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/UserTokenEndpointService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/UserTokenEndpointService.cs
@@ -115,6 +115,11 @@ public class UserTokenEndpointService : IUserTokenEndpointService
         
         var oidc = await _configurationService.GetOpenIdConnectConfigurationAsync(parameters.ChallengeScheme);
 
+        if (string.IsNullOrEmpty(oidc.RevocationEndpoint))
+        {
+            throw new InvalidOperationException("Revocation endpoint not configured");
+        }
+
         var request = new TokenRevocationRequest
         {
             Address = oidc.RevocationEndpoint,


### PR DESCRIPTION
Exception when an OIDC provider has no revocation endpoint even if you are not trying to revoke a refresh token. Occurs when the OpenIdConnectConfigurationService tries to construct a OpenIdConnectClientConfiguration, 