### PR TITLE
add Parameters to ClientCredentialsClient for sending 'audience' parameter

### DIFF
--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectClientAccessTokenHandler.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectClientAccessTokenHandler.cs
@@ -62,6 +62,7 @@ public class OpenIdConnectClientAccessTokenHandler : DelegatingHandler
             ForceRenewal = forceRenewal,
             Scope = _parameters.Scope,
             Resource = _parameters.Resource,
+            Parameters = _parameters.Parameters,
             Assertion = _parameters.Assertion,
             Context =  _parameters.Context
         };

--- a/src/Duende.AccessTokenManagement/ClientCredentialsClient.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsClient.cs
@@ -45,6 +45,11 @@ public class ClientCredentialsClient
     /// The HTTP client name to use for the backchannel operations, will fall back to the standard backchannel client if not set
     /// </summary>
     public string? HttpClientName { get; set; }
+
+    /// <summary>
+    /// Additional parameters to send with token requests.
+    /// </summary>
+    public Parameters Parameters { get; set; } = new Parameters();
     
     /// <summary>
     /// The HTTP client instance to use for the back-channel operations, will override the HTTP client name if set

--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
@@ -62,6 +62,7 @@ public class ClientCredentialsTokenEndpointService : IClientCredentialsTokenEndp
             ClientSecret = client.ClientSecret,
             ClientCredentialStyle = client.ClientCredentialStyle
         };
+        request.Parameters.AddRange(client.Parameters);
         
         parameters ??= new TokenRequestParameters();
         
@@ -80,6 +81,8 @@ public class ClientCredentialsTokenEndpointService : IClientCredentialsTokenEndp
             request.Resource.Clear();
             request.Resource.Add(client.Resource);
         }
+
+        request.Parameters.AddRange(parameters.Parameters);
 
         // if assertion gets passed in explicitly, use it.
         // otherwise call assertion service

--- a/src/Duende.AccessTokenManagement/TokenRequestParameters.cs
+++ b/src/Duende.AccessTokenManagement/TokenRequestParameters.cs
@@ -24,6 +24,11 @@ public class TokenRequestParameters
     /// Override the statically configured resource parameter.
     /// </summary>
     public string? Resource { get; set; }
+
+    /// <summary>
+    /// Additional parameters to send.
+    /// </summary>
+    public Parameters Parameters { get; set; } = new Parameters();
     
     /// <summary>
     /// Specifies the client assertion.

--- a/test/Tests/ClientTokenManagementTests.cs
+++ b/test/Tests/ClientTokenManagementTests.cs
@@ -45,12 +45,14 @@ public class ClientTokenManagementTests
 
                 client.Scope = "scope";
                 client.Resource = "resource";
+                client.Parameters.Add("audience", "audience");
             });
 
         var expectedRequestFormData = new Dictionary<string, string>
         {
             { "scope", "scope" },
             { "resource", "resource" },
+            { "audience", "audience" },
         };
 
         if (style == ClientCredentialStyle.PostBody)
@@ -158,18 +160,24 @@ public class ClientTokenManagementTests
 
                 client.Scope = "scope";
                 client.Resource = "resource";
+                client.Parameters.Add("audience", "audience");
             });
 
         var request = new TokenRequestParameters
         {
             Scope = "scope_per_request",
-            Resource = "resource_per_request"
+            Resource = "resource_per_request",
+            Parameters =
+            {
+                { "audience", "audience_per_request" },
+            },
         };
 
         var expectedRequestFormData = new Dictionary<string, string>
         {
             { "scope", "scope_per_request" },
             { "resource", "resource_per_request" },
+            { "audience", "audience_per_request" },
         };
 
         var response = new


### PR DESCRIPTION
**What issue does this PR address?**

Auth0 requires sending the `audience` parameter with a client credentials token request. This adds a `Parameters` property to `ClientCredentialsClient` that allows specifying any arbitrary parameters with a token request. Fixes #9. I know there Dominick said "we will look into it", but I figured if I wrote the PR it might make it into 1.0 😄  If there's some reason not to merge this, I understand.

I initialized `Parameters` automatically to follow the same pattern as [ProtocolRequest in IdentityModel.Client](https://github.com/IdentityModel/IdentityModel/blob/2e94543bb365995fa3fc9201c407acb2b9578d61/src/Client/Messages/ProtocolRequest.cs#L81).

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
