### PR TITLE
Added workaround for concurrent requests that require refresh token r…

### DIFF
--- a/src/Duende.AccessTokenManagement.OpenIdConnect/UserTokenRequestSynchronization.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/UserTokenRequestSynchronization.cs
@@ -27,7 +27,12 @@ internal class UserTokenRequestSynchronization : IUserTokenRequestSynchronizatio
         }
         finally
         {
-            _dictionary.TryRemove(name, out _);
+            // Workaround "caching" for concurrent requests that are using the same cookie / refresh token
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(10000);
+                _dictionary.TryRemove(name, out _);
+            });
         }
     }
 }


### PR DESCRIPTION
…enewal in UserTokenRequestSynchronization

**What issue does this PR address?**

When proxying concurrent requests (using the same cookie / refresh token) from a BFF client to an remote API that require refresh token renewal, all but one request will fail when the refresh token is configured to be consumed only once.

A minor modification to the `UserTokenRequestSynchronization` by adding a slight time window until the key will be removed will act as a short-lived cache and handle the above scenario.

Let me know if you would consider this PR and want me to do any changes or if this is out of scope.