### PR TITLE
Allow dependency injection in client configuration

### DIFF
--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementBuilder.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Duende.AccessTokenManagement;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -31,6 +32,18 @@ public class ClientCredentialsTokenManagementBuilder
     public ClientCredentialsTokenManagementBuilder AddClient(string name, Action<ClientCredentialsClient> configureOptions)
     {
         _services.Configure(name, configureOptions);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a client credentials client to the token management system
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="configureOptions"></param>
+    /// <returns></returns>
+    public ClientCredentialsTokenManagementBuilder AddClient(string name, Action<IServiceProvider, ClientCredentialsClient> configureOptions)
+    {
+        _services.AddTransient<IConfigureOptions<ClientCredentialsClient>>(sp => new ConfigureClientCredentialsOptions(name, sp, configureOptions));
         return this;
     }
 }

--- a/src/Duende.AccessTokenManagement/ConfigureClientCredentialsOptions.cs
+++ b/src/Duende.AccessTokenManagement/ConfigureClientCredentialsOptions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+
+namespace Duende.AccessTokenManagement
+{
+    /// <summary>
+    /// Named options to allow dependency injection for client configuration
+    /// </summary>
+    internal class ConfigureClientCredentialsOptions : IConfigureNamedOptions<ClientCredentialsClient>
+    {
+        private readonly string _name;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly Action<IServiceProvider, ClientCredentialsClient> _configureOptions;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="serviceProvider"></param>
+        /// <param name="configureOptions"></param>
+        public ConfigureClientCredentialsOptions(string name, IServiceProvider serviceProvider, Action<IServiceProvider, ClientCredentialsClient> configureOptions)
+        {
+            _name = name;
+            _serviceProvider = serviceProvider;
+            _configureOptions = configureOptions;
+        }
+
+        /// <inheritdoc />
+        public void Configure(ClientCredentialsClient options)
+        { }
+
+        /// <inheritdoc />
+        public void Configure(string? name, ClientCredentialsClient options)
+        {
+            if (name == _name)
+            {
+                _configureOptions(_serviceProvider, options);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
Every time I use this package (or its predecessor) I run into the issue of needing to inject dependencies into the code that configures the (client credentials) client. This PR adds an overload for the `ClientCredentialsTokenManagementBuilder.AddClient` method that gives access to `IServiceProvider`.

I am able to use _largely_ the same approach from our own private code base, but I know many other people have run into this issue over the years. Therefore I think it would be a nice addition. Also the API isn't quite as nice from within our own code base, because the `ClientCredentialsTokenManagementBuilder` doesn't give access to the `IServiceCollection` it holds a reference to. That means we can't write this as an extension method on the existing builder class.

I've added a single test, which – perhaps somewhat confusingly – makes use of the `TokenClientOptions` class to exercise the dependency injection. I did not want to add any dependencies on mock frameworks and I wasn't sure if it was okay to define a private class just for testing purposes. I couldn't find any precedent for this in the existing code. Basically, it's a result of trying to color within the lines 🙂

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
