### PR TITLE
Make retry if 401 configurable

### DIFF
--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectClientAccessTokenHandler.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectClientAccessTokenHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace Duende.AccessTokenManagement.OpenIdConnect;
 
@@ -23,15 +24,17 @@ public class OpenIdConnectClientAccessTokenHandler : AccessTokenHandler
     /// <param name="dPoPProofService"></param>
     /// <param name="dPoPNonceStore"></param>
     /// <param name="httpContextAccessor"></param>
+    /// <param name="options"></param>
     /// <param name="logger"></param>
     /// <param name="parameters"></param>
     public OpenIdConnectClientAccessTokenHandler(
         IDPoPProofService dPoPProofService,
         IDPoPNonceStore dPoPNonceStore,
-        IHttpContextAccessor httpContextAccessor, 
+        IHttpContextAccessor httpContextAccessor,
+        IOptions<ClientCredentialsTokenManagementOptions> options,
         ILogger<OpenIdConnectClientAccessTokenHandler> logger,
         UserTokenRequestParameters? parameters = null)
-        : base(dPoPProofService, dPoPNonceStore, logger)
+        : base(dPoPProofService, dPoPNonceStore, options, logger)
     {
         _httpContextAccessor = httpContextAccessor;
         _parameters = parameters ?? new UserTokenRequestParameters();

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
@@ -58,7 +58,7 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
 
         return services.AddOpenIdConnectAccessTokenManagement();
     }
-    
+
     /// <summary>
     /// Adds a named HTTP client for the factory that automatically sends the current user access token
     /// </summary>
@@ -81,7 +81,7 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
         return services.AddHttpClient(name)
             .AddUserAccessTokenHandler(parameters);
     }
-    
+
     /// <summary>
     /// Adds a named HTTP client for the factory that automatically sends the current user access token
     /// </summary>
@@ -104,7 +104,7 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
         return services.AddHttpClient(name)
             .AddUserAccessTokenHandler(parameters);
     }
-    
+
     /// <summary>
     /// Adds a named HTTP client for the factory that automatically sends the current user access token
     /// </summary>
@@ -128,7 +128,7 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
             .AddClientAccessTokenHandler(parameters);
     }
 
-    
+
     /// <summary>
     /// Adds the user access token handler to an HttpClient
     /// </summary>
@@ -144,12 +144,13 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
             var dpopService = provider.GetRequiredService<IDPoPProofService>();
             var dpopNonceStore = provider.GetRequiredService<IDPoPNonceStore>();
             var contextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
+            var options = provider.GetRequiredService<IOptions<ClientCredentialsTokenManagementOptions>>();
             var logger = provider.GetRequiredService<ILogger<OpenIdConnectClientAccessTokenHandler>>();
-            
-            return new OpenIdConnectUserAccessTokenHandler(dpopService, dpopNonceStore, contextAccessor, logger, parameters);
+
+            return new OpenIdConnectUserAccessTokenHandler(dpopService, dpopNonceStore, contextAccessor, options, logger, parameters);
         });
     }
-    
+
     /// <summary>
     /// Adds the user access token handler to an HttpClient
     /// </summary>
@@ -165,9 +166,10 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
             var dpopService = provider.GetRequiredService<IDPoPProofService>();
             var dpopNonceStore = provider.GetRequiredService<IDPoPNonceStore>();
             var contextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
+            var options = provider.GetRequiredService<IOptions<ClientCredentialsTokenManagementOptions>>();
             var logger = provider.GetRequiredService<ILogger<OpenIdConnectClientAccessTokenHandler>>();
 
-            return new OpenIdConnectClientAccessTokenHandler(dpopService, dpopNonceStore, contextAccessor, logger, parameters);
+            return new OpenIdConnectClientAccessTokenHandler(dpopService, dpopNonceStore, contextAccessor, options, logger, parameters);
         });
     }
 }

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectUserAccessTokenHandler.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectUserAccessTokenHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace Duende.AccessTokenManagement.OpenIdConnect;
 
@@ -23,15 +24,17 @@ public class OpenIdConnectUserAccessTokenHandler : AccessTokenHandler
     /// <param name="dPoPProofService"></param>
     /// <param name="dPoPNonceStore"></param>
     /// <param name="httpContextAccessor"></param>
+    /// <param name="options"></param>
     /// <param name="logger"></param>
     /// <param name="parameters"></param>
     public OpenIdConnectUserAccessTokenHandler(
         IDPoPProofService dPoPProofService,
         IDPoPNonceStore dPoPNonceStore,
         IHttpContextAccessor httpContextAccessor,
+        IOptions<ClientCredentialsTokenManagementOptions> options,
         ILogger<OpenIdConnectClientAccessTokenHandler> logger,
         UserTokenRequestParameters? parameters = null)
-        : base(dPoPProofService, dPoPNonceStore, logger)
+        : base(dPoPProofService, dPoPNonceStore, options, logger)
     {
         _httpContextAccessor = httpContextAccessor;
         _parameters = parameters ?? new UserTokenRequestParameters();

--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenHandler.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenHandler.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace Duende.AccessTokenManagement;
 
@@ -21,15 +22,17 @@ public class ClientCredentialsTokenHandler : AccessTokenHandler
     /// <param name="dPoPProofService"></param>
     /// <param name="dPoPNonceStore"></param>
     /// <param name="accessTokenManagementService">The Access Token Management Service</param>
+    /// <param name="options"></param>
     /// <param name="logger"></param>
     /// <param name="tokenClientName">The name of the token client configuration</param>
     public ClientCredentialsTokenHandler(
         IDPoPProofService dPoPProofService,
         IDPoPNonceStore dPoPNonceStore,
         IClientCredentialsTokenManagementService accessTokenManagementService,
+        IOptions<ClientCredentialsTokenManagementOptions> options,
         ILogger<ClientCredentialsTokenHandler> logger,
-        string tokenClientName) 
-        : base(dPoPProofService, dPoPNonceStore, logger)
+        string tokenClientName)
+        : base(dPoPProofService, dPoPNonceStore, options, logger)
     {
         _accessTokenManagementService = accessTokenManagementService;
         _tokenClientName = tokenClientName;
@@ -41,7 +44,7 @@ public class ClientCredentialsTokenHandler : AccessTokenHandler
         var parameters = new TokenRequestParameters
         {
             ForceRenewal = forceRenewal
-        }; 
+        };
         return _accessTokenManagementService.GetAccessTokenAsync(_tokenClientName, parameters, cancellationToken);
     }
 }

--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementOptions.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementOptions.cs
@@ -17,4 +17,9 @@ public class ClientCredentialsTokenManagementOptions
     /// Value to subtract from token lifetime for the cache entry lifetime (defaults to 60 seconds)
     /// </summary>
     public int CacheLifetimeBuffer { get; set; } = 60;
+
+    /// <summary>
+    /// Flag indicates if it is required to retry request if response has status 401
+    /// </summary>
+    public bool RetryOn401 { get; set; } = true;
 }

--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementServiceCollectionExtensions.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using Duende.AccessTokenManagement;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -140,8 +141,9 @@ public static class ClientCredentialsTokenManagementServiceCollectionExtensions
             var dpopNonceStore = provider.GetRequiredService<IDPoPNonceStore>();
             var accessTokenManagementService = provider.GetRequiredService<IClientCredentialsTokenManagementService>();
             var logger = provider.GetRequiredService<ILogger<ClientCredentialsTokenHandler>>();
+            var options = provider.GetRequiredService<IOptions<ClientCredentialsTokenManagementOptions>>();
 
-            return new ClientCredentialsTokenHandler(dpopService, dpopNonceStore, accessTokenManagementService, logger, tokenClientName);
+            return new ClientCredentialsTokenHandler(dpopService, dpopNonceStore, accessTokenManagementService, options, logger, tokenClientName);
         });
     }
 }


### PR DESCRIPTION
Added ClientCredentialsTokenManagementOptions dependency to AccessTokenHandler

**What issue does this PR address?**

No issue, I decided it'd be faster to create small PR, that to create an issue. I'll describe it here.
We have two services, Alpha and Bravo. Bravo sends requests to Alpha using Refit library. In case Alpha returns 4xx code response, Bravo logs it and returns the same error code to front-end. When the error occurres too many times Alpha changes client status to "locked" and returns unique error code "User is locked from now on". And if Bravo continues sending requests to Alpha, Alpha returns just "User is locked" error code. This is how it should look:

| # | Status Code | Error Code |
|--------|--------|--------|
| 1 | 403 | Invalid parameter |
| 2 | 403 | Invalid parameter |
| 3 | 401 | User is locked from now on |
| 4 | 401 | User is locked |
| 5 | 401 | User is locked | 

And this is how it actually looks now:

| # | Status Code | Error Code |
|--------|--------|--------|
| 1 | 403 | Invalid parameter |
| 2 | 403 | Invalid parameter |
| 3 | 401 | User is locked |
| 4 | 401 | User is locked |
| 5 | 401 | User is locked | 

It took some time to find, that we actually send two requests in the 3-rd one, not one. And the first would return "User is locked from now on", if it was not disposed.

So I suggest to add `RetryOn401` flag to the `ClientCredentialsTokenManagementOptions` object, so it can be configured for each service individually. I set default value `true` for this flag, so this PR shall not break anything.


