### PR TITLE
Fix bug where use of resource param is not triggering renewal

### DIFF
--- a/samples/Web/Controllers/HomeController.cs
+++ b/samples/Web/Controllers/HomeController.cs
@@ -70,6 +70,20 @@ public class HomeController : Controller
     }
 
     [AllowAnonymous]
+    public async Task<IActionResult> CallApiAsUserResourceIndicator()
+    {
+        var token = await HttpContext.GetUserAccessTokenAsync(new UserTokenRequestParameters { Resource = "urn:resource1" });
+        var client = _httpClientFactory.CreateClient();
+        client.SetToken(token.AccessTokenType!, token.AccessToken!);
+
+        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/test");
+
+        ViewBag.Json = PrettyPrint(response);
+        return View("CallApi");
+    }
+
+
+    [AllowAnonymous]
     public async Task<IActionResult> CallApiAsClientExtensionMethod()
     {
         var token = await HttpContext.GetClientAccessTokenAsync();
@@ -81,7 +95,21 @@ public class HomeController : Controller
         ViewBag.Json = PrettyPrint(response);
         return View("CallApi");
     }
+
+    [AllowAnonymous]
+    public async Task<IActionResult> CallApiAsClientResourceIndicator()
+    {
+        var token = await HttpContext.GetClientAccessTokenAsync(new UserTokenRequestParameters { Resource = "urn:resource1" });
+        var client = _httpClientFactory.CreateClient();
+        client.SetToken(token.AccessTokenType!, token.AccessToken!);
+
+        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/test");
+
+        ViewBag.Json = PrettyPrint(response);
+        return View("CallApi");
+    }
     
+
     [AllowAnonymous]
     public async Task<IActionResult> CallApiAsClientFactory()
     {

--- a/samples/Web/Properties/launchSettings.json
+++ b/samples/Web/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Web": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "https://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/samples/Web/Startup.cs
+++ b/samples/Web/Startup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,6 +34,7 @@ public static class Startup
             .AddOpenIdConnect("oidc", options =>
             {
                 options.Authority = "https://demo.duendesoftware.com";
+                //options.Authority = "https://localhost:5001";
 
                 options.ClientId = "interactive.confidential.short";
                 options.ClientSecret = "secret";
@@ -46,6 +48,7 @@ public static class Startup
                 options.Scope.Add("email");
                 options.Scope.Add("offline_access");
                 options.Scope.Add("api");
+                options.Scope.Add("resource1.scope1");
 
                 options.GetClaimsFromUserInfoEndpoint = true;
                 options.SaveTokens = true;
@@ -55,6 +58,12 @@ public static class Startup
                 {
                     NameClaimType = "name",
                     RoleClaimType = "role"
+                };
+
+                options.Events.OnRedirectToIdentityProvider = ctx => 
+                {
+                    ctx.ProtocolMessage.Resource = "urn:resource1";
+                    return Task.CompletedTask;
                 };
             });
 

--- a/samples/Web/Views/Home/Index.cshtml
+++ b/samples/Web/Views/Home/Index.cshtml
@@ -9,5 +9,7 @@
 <a href="./home/CallApiAsClientFactory">HTTP client factory</a>
 |
 <a href="./home/CallApiAsClientFactoryTyped">HTTP client factory (typed)</a>
+|
+<a href="./home/CallApiAsClientResourceIndicator">Use resource indicator</a>
 
 

--- a/samples/Web/Views/Home/Secure.cshtml
+++ b/samples/Web/Views/Home/Secure.cshtml
@@ -9,6 +9,8 @@
 <a href="./CallApiAsUserFactory">HTTP client factory</a>
 |
 <a href="./CallApiAsUserFactoryTyped">HTTP client factory (typed)</a>
+|
+<a href="./CallApiAsUserResourceIndicator">Use resource indicator</a>
 
 <h3>Call API as Client</h3>
 
@@ -17,7 +19,8 @@
 <a href="./CallApiAsClientFactory">HTTP client factory</a>
 |
 <a href="./CallApiAsClientFactoryTypes">HTTP client factory (typed)</a>
-
+|
+<a href="./CallApiAsClientResourceIndicator">Use resource indicator</a>
 
 <h2>Claims</h2>
 

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
@@ -102,13 +102,14 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
             {
                 dpopKeyName += $"::{parameters.Resource}";
             }
-            var expiresName = $"{TokenPrefix}expires_at"; string? refreshToken = null;
+            var expiresName = $"{TokenPrefix}expires_at";
             if (!string.IsNullOrEmpty(parameters.Resource))
             {
                 expiresName += $"::{parameters.Resource}";
             }
             const string refreshTokenName = $"{TokenPrefix}{OpenIdConnectParameterNames.RefreshToken}";
 
+            string? refreshToken = null;
             string? accessToken = null;
             string? accessTokenType = null;
             string? dpopKey = null;
@@ -156,7 +157,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
             UserToken token,
             UserTokenRequestParameters? parameters = null)
         {
-            parameters ??= new ();
+            parameters ??= new();
 
             // check the cache in case the cookie was re-issued via StoreTokenAsync
             // we use String.Empty as the key for a null SignInScheme
@@ -173,13 +174,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
             // in case you want to filter certain claims before re-issuing the authentication session
             var transformedPrincipal = await FilterPrincipalAsync(result.Principal!).ConfigureAwait(false);
 
-            var expiresName = "expires_at";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                expiresName += $"::{parameters.Resource}";
-            }
-
-            var tokenName = OpenIdConnectParameterNames.AccessToken;
+            var tokenName = $"{TokenPrefix}{OpenIdConnectParameterNames.AccessToken}";
             if (!string.IsNullOrEmpty(parameters.Resource))
             {
                 tokenName += $"::{parameters.Resource}";
@@ -194,7 +189,11 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
             {
                 dpopKeyName += $"::{parameters.Resource}";
             }
-
+            var expiresName = $"{TokenPrefix}expires_at";
+            if (!string.IsNullOrEmpty(parameters.Resource))
+            {
+                expiresName += $"::{parameters.Resource}";
+            }
             var refreshTokenName = $"{OpenIdConnectParameterNames.RefreshToken}";
 
             if (AppendChallengeSchemeToTokenNames(parameters))
@@ -206,13 +205,13 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
                 expiresName += $"||{parameters.ChallengeScheme}";
             }
 
-            result.Properties!.Items[$"{TokenPrefix}{tokenName}"] = token.AccessToken;
-            result.Properties!.Items[$"{TokenPrefix}{tokenTypeName}"] = token.AccessTokenType;
+            result.Properties!.Items[tokenName] = token.AccessToken;
+            result.Properties!.Items[tokenTypeName] = token.AccessTokenType;
             if (token.DPoPJsonWebKey != null)
             {
-                result.Properties!.Items[$"{TokenPrefix}{dpopKeyName}"] = token.DPoPJsonWebKey;
+                result.Properties!.Items[dpopKeyName] = token.DPoPJsonWebKey;
             }
-            result.Properties!.Items[$"{TokenPrefix}{expiresName}"] = token.Expiration.ToString("o", CultureInfo.InvariantCulture);
+            result.Properties!.Items[expiresName] = token.Expiration.ToString("o", CultureInfo.InvariantCulture);
 
             if (token.RefreshToken != null)
             {

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/UserAccessTokenManagementService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/UserAccessTokenManagementService.cs
@@ -83,7 +83,8 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
             return userToken;
         }
 
-        if (userToken.AccessToken.IsMissing() && userToken.RefreshToken.IsPresent())
+        var needsRenewal = userToken.AccessToken.IsMissing() && userToken.RefreshToken.IsPresent();
+        if (needsRenewal)
         {
             _logger.LogDebug(
                 "No access token found in user token store for user {user} / resource {resource}. Trying to refresh.",
@@ -91,7 +92,7 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
         }
 
         var dtRefresh = userToken.Expiration.Subtract(_options.RefreshBeforeExpiration);
-        if (dtRefresh < _clock.UtcNow || parameters.ForceRenewal)
+        if (dtRefresh < _clock.UtcNow || parameters.ForceRenewal || needsRenewal)
         {
             _logger.LogDebug("Token for user {user} needs refreshing.", userName);
 

--- a/test/Tests/UserTokenManagementTests.cs
+++ b/test/Tests/UserTokenManagementTests.cs
@@ -262,7 +262,7 @@ public class UserTokenManagementTests : IntegrationTestBase
         token.ShouldNotBeNull();
         token.IsError.ShouldBeFalse();
         token.AccessToken.ShouldBe("refreshed2_access_token");
-        token.AccessTokenType.ShouldBe("token_type");
+        token.AccessTokenType.ShouldBe("token_type2");
         token.RefreshToken.ShouldBe("refreshed2_refresh_token");
         token.Expiration.ShouldNotBe(DateTimeOffset.MaxValue);
     }


### PR DESCRIPTION
This scenario uncovered that there were some other bugs in the store as well, not getting the key names correct in the AuthProperties Items collection. This was the same underlying reason the resource param wasn't working.

Closes: https://github.com/DuendeSoftware/Duende.AccessTokenManagement/issues/34