### PR TITLE
Make creation of ClientCredentialTokenRequest virtual

### DIFF
--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
@@ -63,14 +63,7 @@ public class ClientCredentialsTokenEndpointService : IClientCredentialsTokenEndp
             throw new InvalidOperationException("unknown client");
         }
 
-        var request = new ClientCredentialsTokenRequest
-        {
-            Address = client.TokenEndpoint,
-            Scope = client.Scope,
-            ClientId = client.ClientId,
-            ClientSecret = client.ClientSecret,
-            ClientCredentialStyle = client.ClientCredentialStyle,
-        };
+        var request = CreateRequest(client);
 
         request.Parameters.AddRange(client.Parameters);
         
@@ -185,5 +178,18 @@ public class ClientCredentialsTokenEndpointService : IClientCredentialsTokenEndp
                 : DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn),
             Scope = response.Scope
         };
+    }
+
+    protected virtual ClientCredentialsTokenRequest CreateRequest(ClientCredentialsClient client)
+    {
+        var request = new ClientCredentialsTokenRequest
+        {
+            Address = client.TokenEndpoint,
+            Scope = client.Scope,
+            ClientId = client.ClientId,
+            ClientSecret = client.ClientSecret,
+            ClientCredentialStyle = client.ClientCredentialStyle,
+        };
+        return request;
     }
 }


### PR DESCRIPTION
**Allow the creation of ClientCredentialsTokenRequest to be overridden**

In some situations we see that it is useful for us to be able to append httpcontext-dependent information as parameters on the `ClientCredentialsTokenRequest` before a token is requested. 

In this PR we propose to allow the creation of ClientCredentialsTokenRequest to be overriden by adding a virtual method for it.
