### PR TITLE
added Scope mapping in RefreshAccessTokenAsync

### DIFF
--- a/src/Duende.AccessTokenManagement.OpenIdConnect/UserTokenEndpointService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/UserTokenEndpointService.cs
@@ -69,7 +69,12 @@ public class UserTokenEndpointService : IUserTokenEndpointService
         };
         
         request.Options.TryAdd(ClientCredentialsTokenManagementDefaults.TokenRequestParametersOptionsName, parameters);
-        
+
+        if (!string.IsNullOrWhiteSpace(parameters.Scope))
+        {
+            request.Scope = parameters.Scope;
+        }
+
         if (!string.IsNullOrEmpty(parameters.Resource))
         {
             request.Resource.Add(parameters.Resource);


### PR DESCRIPTION
Scope mapping was missing when preparing Request for RefreshAccessTokenAsync