### PR TITLE
Support for .NET 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
+          6.0.x
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
           8.0.x
         
     - run: dotnet --info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-          6.0.x
+          8.0.x
         
     - run: dotnet --info
     

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,7 +19,6 @@
         <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(FrameworkVersion)" />
         <PackageReference Update="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(FrameworkVersion)" />
         <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
-        <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(FrameworkVersion)" />
 
         <!-- Microsoft Extensions -->
         <PackageReference Update="Microsoft.Extensions.Caching.Abstractions" Version="$(ExtensionsVersion)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,35 @@
+<Project>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <FrameworkVersion>8.0.0</FrameworkVersion>
+        <ExtensionsVersion>8.0.0</ExtensionsVersion>
+        <WilsonVersion>7.0.3</WilsonVersion>
+        <IdentityServerVersion>7.0.0-preview.2</IdentityServerVersion>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+        <FrameworkVersion>6.0.0</FrameworkVersion>
+        <ExtensionsVersion>6.0.0</ExtensionsVersion>
+        <WilsonVersion>6.15.0</WilsonVersion>
+        <IdentityServerVersion>6.3.6</IdentityServerVersion>
+    </PropertyGroup>
+
+
+    <ItemGroup>
+        <!-- ASP.NET -->
+        <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(FrameworkVersion)" />
+        <PackageReference Update="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(FrameworkVersion)" />
+        <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
+        <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(FrameworkVersion)" />
+
+        <!-- Microsoft Extensions -->
+        <PackageReference Update="Microsoft.Extensions.Caching.Abstractions" Version="$(ExtensionsVersion)" />
+        <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />
+        <PackageReference Update="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
+        <PackageReference Update="Microsoft.Extensions.Http" Version="$(ExtensionsVersion)" />
+        <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
+
+        <!-- Wilson -->
+        <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="$(WilsonVersion)" />
+
+    </ItemGroup>
+</Project>

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/samples/BlazorServer/BlazorServer.csproj
+++ b/samples/BlazorServer/BlazorServer.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>aspnet-BlazorServer-AF0F1063-736A-4F96-BAF4-B06CE5D44F0D</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
-        <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Web/Controllers/HomeController.cs
+++ b/samples/Web/Controllers/HomeController.cs
@@ -33,7 +33,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
+        var response = await client.GetStringAsync($"{Startup.ApiBaseUrl}/test");
         ViewBag.Json = PrettyPrint(response);
 
         return View("CallApi");
@@ -45,7 +45,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
             
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
+        var response = await client.GetStringAsync($"{Startup.ApiBaseUrl}/test");
         ViewBag.Json = PrettyPrint(response);
 
         return View("CallApi");
@@ -76,7 +76,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
+        var response = await client.GetStringAsync($"{Startup.ApiBaseUrl}/test");
 
         ViewBag.Json = PrettyPrint(response);
         return View("CallApi");
@@ -90,7 +90,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
+        var response = await client.GetStringAsync($"{Startup.ApiBaseUrl}/test");
         
         ViewBag.Json = PrettyPrint(response);
         return View("CallApi");
@@ -103,7 +103,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
+        var response = await client.GetStringAsync($"{Startup.ApiBaseUrl}/test");
 
         ViewBag.Json = PrettyPrint(response);
         return View("CallApi");

--- a/samples/Web/Controllers/HomeController.cs
+++ b/samples/Web/Controllers/HomeController.cs
@@ -33,7 +33,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/test");
+        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
         ViewBag.Json = PrettyPrint(response);
 
         return View("CallApi");
@@ -45,7 +45,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
             
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/test");
+        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
         ViewBag.Json = PrettyPrint(response);
 
         return View("CallApi");
@@ -76,7 +76,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/test");
+        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
 
         ViewBag.Json = PrettyPrint(response);
         return View("CallApi");
@@ -90,7 +90,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/test");
+        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
         
         ViewBag.Json = PrettyPrint(response);
         return View("CallApi");
@@ -103,7 +103,7 @@ public class HomeController : Controller
         var client = _httpClientFactory.CreateClient();
         client.SetToken(token.AccessTokenType!, token.AccessToken!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/test");
+        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
 
         ViewBag.Json = PrettyPrint(response);
         return View("CallApi");

--- a/samples/Web/Startup.cs
+++ b/samples/Web/Startup.cs
@@ -16,6 +16,12 @@ namespace Web;
 
 public static class Startup
 {
+    public const bool UseDPoP = false;
+
+    public const string ApiBaseUrl = UseDPoP ? 
+        "https://demo.duendesoftware.com/api/dpop/" :
+        "https://demo.duendesoftware.com/api/";
+
     internal static WebApplication ConfigureServices(this WebApplicationBuilder builder)
     {
         builder.Services.AddControllersWithViews();
@@ -74,32 +80,29 @@ public static class Startup
         
         builder.Services.AddOpenIdConnectAccessTokenManagement(options => 
         {
-            // if you uncomment this line, then be sure to change the URL for the "user_client"
-            // to include "dpop/" at the end, since that's the DPoP enabled API path
-            options.DPoPJsonWebKey = jwk;
+            options.DPoPJsonWebKey = UseDPoP ? jwk : null; ;
         });
 
         // registers HTTP client that uses the managed user access token
         builder.Services.AddUserAccessTokenHttpClient("user_client",
             configureClient: client => {
-                //client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/");
-                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
+                client.BaseAddress = new Uri(ApiBaseUrl);
             });
 
         // registers HTTP client that uses the managed client access token
         builder.Services.AddClientAccessTokenHttpClient("client",
-            configureClient: client => { client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/"); });
+            configureClient: client => { client.BaseAddress = new Uri(ApiBaseUrl); });
 
         // registers a typed HTTP client with token management support
         builder.Services.AddHttpClient<TypedUserClient>(client =>
             {
-                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
+                client.BaseAddress = new Uri(ApiBaseUrl);
             })
             .AddUserAccessTokenHandler();
 
         builder.Services.AddHttpClient<TypedClientClient>(client =>
             {
-                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
+                client.BaseAddress = new Uri(ApiBaseUrl);
             })
             .AddClientAccessTokenHandler();
 

--- a/samples/Web/Startup.cs
+++ b/samples/Web/Startup.cs
@@ -76,30 +76,30 @@ public static class Startup
         {
             // if you uncomment this line, then be sure to change the URL for the "user_client"
             // to include "dpop/" at the end, since that's the DPoP enabled API path
-            //options.DPoPJsonWebKey = jwk;
+            options.DPoPJsonWebKey = jwk;
         });
 
         // registers HTTP client that uses the managed user access token
         builder.Services.AddUserAccessTokenHttpClient("user_client",
             configureClient: client => {
-                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/");
-                //client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
+                //client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/");
+                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
             });
 
         // registers HTTP client that uses the managed client access token
         builder.Services.AddClientAccessTokenHttpClient("client",
-            configureClient: client => { client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/"); });
+            configureClient: client => { client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/"); });
 
         // registers a typed HTTP client with token management support
         builder.Services.AddHttpClient<TypedUserClient>(client =>
             {
-                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/");
+                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
             })
             .AddUserAccessTokenHandler();
 
         builder.Services.AddHttpClient<TypedClientClient>(client =>
             {
-                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/");
+                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
             })
             .AddClientAccessTokenHandler();
 

--- a/samples/Web/Views/Home/Index.cshtml
+++ b/samples/Web/Views/Home/Index.cshtml
@@ -4,12 +4,16 @@
 
 <h3>Call API as Client</h3>
 
-<a href="./home/CallApiAsClientExtensionMethod">Extension method</a>
-|
-<a href="./home/CallApiAsClientFactory">HTTP client factory</a>
-|
-<a href="./home/CallApiAsClientFactoryTyped">HTTP client factory (typed)</a>
-|
-<a href="./home/CallApiAsClientResourceIndicator">Use resource indicator</a>
-
-
+@if (!Startup.UseDPoP)
+{
+    <a asp-controller="Home" asp-action = "CallApiAsClientExtensionMethod" > Extension method </a > 
+    @("|")
+}
+<a asp-controller="Home" asp-action="CallApiAsClientFactory">HTTP client factory</a> 
+@("|")
+<a asp-controller="Home" asp-action="CallApiAsClientFactoryTyped">HTTP client factory (typed)</a>
+@if (!Startup.UseDPoP)
+{
+    @("|")
+    <a asp-controller="Home" asp-action="CallApiAsClientResourceIndicator">Use resource indicator</a>
+}

--- a/samples/Web/Views/Home/Secure.cshtml
+++ b/samples/Web/Views/Home/Secure.cshtml
@@ -2,25 +2,37 @@
 
 <h3>Call API as User</h3>
 
-<a href="./CallApiAsUserManual">Manual</a>
-|
-<a href="./CallApiAsUserExtensionMethod">Extension method</a>
-|
-<a href="./CallApiAsUserFactory">HTTP client factory</a>
-|
-<a href="./CallApiAsUserFactoryTyped">HTTP client factory (typed)</a>
-|
-<a href="./CallApiAsUserResourceIndicator">Use resource indicator</a>
+@if (!Startup.UseDPoP)
+{
+    <a asp-controller="Home" asp-action="CallApiAsUserManual">Manual</a>
+    @("|")
+    <a asp-controller="Home" asp-action="CallApiAsUserExtensionMethod"> Extension method </a>
+    @("|")
+}
+<a asp-controller="Home" asp-action="CallApiAsUserFactory">HTTP client factory</a>
+@("|")
+<a asp-controller="Home" asp-action="CallApiAsUserFactoryTyped">HTTP client factory (typed)</a>
+@if (!Startup.UseDPoP)
+{
+    @("|")
+    <a asp-controller="Home" asp-action="CallApiAsUserResourceIndicator">Use resource indicator</a>
+}
 
 <h3>Call API as Client</h3>
 
-<a href="./CallApiAsClientExtensionMethod">Extension method</a>
-|
-<a href="./CallApiAsClientFactory">HTTP client factory</a>
-|
-<a href="./CallApiAsClientFactoryTypes">HTTP client factory (typed)</a>
-|
-<a href="./CallApiAsClientResourceIndicator">Use resource indicator</a>
+@if (!Startup.UseDPoP)
+{
+    <a asp-controller="Home" asp-action="CallApiAsClientExtensionMethod"> Extension method </a>
+    @("|")
+}
+<a asp-controller="Home" asp-action="CallApiAsClientFactory">HTTP client factory</a>
+@("|")
+<a asp-controller="Home" asp-action="CallApiAsClientFactoryTyped">HTTP client factory (typed)</a>
+@if (!Startup.UseDPoP)
+{
+    @("|")
+    <a asp-controller="Home" asp-action="CallApiAsClientResourceIndicator">Use resource indicator</a>
+}
 
 <h2>Claims</h2>
 

--- a/samples/Web/Web.csproj
+++ b/samples/Web/Web.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/WebJarJwt/ClientAssertionService.cs
+++ b/samples/WebJarJwt/ClientAssertionService.cs
@@ -21,7 +21,20 @@ public class ClientAssertionService : IClientAssertionService
     private readonly IOpenIdConnectConfigurationService _configurationService;
 
     private static string RsaKey =
-        "{'d':'GmiaucNIzdvsEzGjZjd43SDToy1pz-Ph-shsOUXXh-dsYNGftITGerp8bO1iryXh_zUEo8oDK3r1y4klTonQ6bLsWw4ogjLPmL3yiqsoSjJa1G2Ymh_RY_sFZLLXAcrmpbzdWIAkgkHSZTaliL6g57vA7gxvd8L4s82wgGer_JmURI0ECbaCg98JVS0Srtf9GeTRHoX4foLWKc1Vq6NHthzqRMLZe-aRBNU9IMvXNd7kCcIbHCM3GTD_8cFj135nBPP2HOgC_ZXI1txsEf-djqJj8W5vaM7ViKU28IDv1gZGH3CatoysYx6jv1XJVvb2PH8RbFKbJmeyUm3Wvo-rgQ','dp':'YNjVBTCIwZD65WCht5ve06vnBLP_Po1NtL_4lkholmPzJ5jbLYBU8f5foNp8DVJBdFQW7wcLmx85-NC5Pl1ZeyA-Ecbw4fDraa5Z4wUKlF0LT6VV79rfOF19y8kwf6MigyrDqMLcH_CRnRGg5NfDsijlZXffINGuxg6wWzhiqqE','dq':'LfMDQbvTFNngkZjKkN2CBh5_MBG6Yrmfy4kWA8IC2HQqID5FtreiY2MTAwoDcoINfh3S5CItpuq94tlB2t-VUv8wunhbngHiB5xUprwGAAnwJ3DL39D2m43i_3YP-UO1TgZQUAOh7Jrd4foatpatTvBtY3F1DrCrUKE5Kkn770M','e':'AQAB','kid':'ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA','kty':'RSA','n':'wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw','p':'7enorp9Pm9XSHaCvQyENcvdU99WCPbnp8vc0KnY_0g9UdX4ZDH07JwKu6DQEwfmUA1qspC-e_KFWTl3x0-I2eJRnHjLOoLrTjrVSBRhBMGEH5PvtZTTThnIY2LReH-6EhceGvcsJ_MhNDUEZLykiH1OnKhmRuvSdhi8oiETqtPE','q':'0CBLGi_kRPLqI8yfVkpBbA9zkCAshgrWWn9hsq6a7Zl2LcLaLBRUxH0q1jWnXgeJh9o5v8sYGXwhbrmuypw7kJ0uA3OgEzSsNvX5Ay3R9sNel-3Mqm8Me5OfWWvmTEBOci8RwHstdR-7b9ZT13jk-dsZI7OlV_uBja1ny9Nz9ts','qi':'pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4'}";
+        """
+        {
+            "d":"GmiaucNIzdvsEzGjZjd43SDToy1pz-Ph-shsOUXXh-dsYNGftITGerp8bO1iryXh_zUEo8oDK3r1y4klTonQ6bLsWw4ogjLPmL3yiqsoSjJa1G2Ymh_RY_sFZLLXAcrmpbzdWIAkgkHSZTaliL6g57vA7gxvd8L4s82wgGer_JmURI0ECbaCg98JVS0Srtf9GeTRHoX4foLWKc1Vq6NHthzqRMLZe-aRBNU9IMvXNd7kCcIbHCM3GTD_8cFj135nBPP2HOgC_ZXI1txsEf-djqJj8W5vaM7ViKU28IDv1gZGH3CatoysYx6jv1XJVvb2PH8RbFKbJmeyUm3Wvo-rgQ",
+            "dp":"YNjVBTCIwZD65WCht5ve06vnBLP_Po1NtL_4lkholmPzJ5jbLYBU8f5foNp8DVJBdFQW7wcLmx85-NC5Pl1ZeyA-Ecbw4fDraa5Z4wUKlF0LT6VV79rfOF19y8kwf6MigyrDqMLcH_CRnRGg5NfDsijlZXffINGuxg6wWzhiqqE",
+            "dq":"LfMDQbvTFNngkZjKkN2CBh5_MBG6Yrmfy4kWA8IC2HQqID5FtreiY2MTAwoDcoINfh3S5CItpuq94tlB2t-VUv8wunhbngHiB5xUprwGAAnwJ3DL39D2m43i_3YP-UO1TgZQUAOh7Jrd4foatpatTvBtY3F1DrCrUKE5Kkn770M",
+            "e":"AQAB",
+            "kid":"ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA",
+            "kty":"RSA",
+            "n":"wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw",
+            "p":"7enorp9Pm9XSHaCvQyENcvdU99WCPbnp8vc0KnY_0g9UdX4ZDH07JwKu6DQEwfmUA1qspC-e_KFWTl3x0-I2eJRnHjLOoLrTjrVSBRhBMGEH5PvtZTTThnIY2LReH-6EhceGvcsJ_MhNDUEZLykiH1OnKhmRuvSdhi8oiETqtPE",
+            "q":"0CBLGi_kRPLqI8yfVkpBbA9zkCAshgrWWn9hsq6a7Zl2LcLaLBRUxH0q1jWnXgeJh9o5v8sYGXwhbrmuypw7kJ0uA3OgEzSsNvX5Ay3R9sNel-3Mqm8Me5OfWWvmTEBOci8RwHstdR-7b9ZT13jk-dsZI7OlV_uBja1ny9Nz9ts",
+            "qi":"pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4"
+        }
+        """;
 
     private static SigningCredentials Credential = new(new JsonWebKey(RsaKey), "RS256");
 

--- a/samples/WebJarJwt/WebJarJwt.csproj
+++ b/samples/WebJarJwt/WebJarJwt.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Worker/ClientAssertionService.cs
+++ b/samples/Worker/ClientAssertionService.cs
@@ -18,7 +18,20 @@ public class ClientAssertionService : IClientAssertionService
     private readonly IOptionsSnapshot<ClientCredentialsClient> _options;
 
     private static string RsaKey =
-        "{'d':'GmiaucNIzdvsEzGjZjd43SDToy1pz-Ph-shsOUXXh-dsYNGftITGerp8bO1iryXh_zUEo8oDK3r1y4klTonQ6bLsWw4ogjLPmL3yiqsoSjJa1G2Ymh_RY_sFZLLXAcrmpbzdWIAkgkHSZTaliL6g57vA7gxvd8L4s82wgGer_JmURI0ECbaCg98JVS0Srtf9GeTRHoX4foLWKc1Vq6NHthzqRMLZe-aRBNU9IMvXNd7kCcIbHCM3GTD_8cFj135nBPP2HOgC_ZXI1txsEf-djqJj8W5vaM7ViKU28IDv1gZGH3CatoysYx6jv1XJVvb2PH8RbFKbJmeyUm3Wvo-rgQ','dp':'YNjVBTCIwZD65WCht5ve06vnBLP_Po1NtL_4lkholmPzJ5jbLYBU8f5foNp8DVJBdFQW7wcLmx85-NC5Pl1ZeyA-Ecbw4fDraa5Z4wUKlF0LT6VV79rfOF19y8kwf6MigyrDqMLcH_CRnRGg5NfDsijlZXffINGuxg6wWzhiqqE','dq':'LfMDQbvTFNngkZjKkN2CBh5_MBG6Yrmfy4kWA8IC2HQqID5FtreiY2MTAwoDcoINfh3S5CItpuq94tlB2t-VUv8wunhbngHiB5xUprwGAAnwJ3DL39D2m43i_3YP-UO1TgZQUAOh7Jrd4foatpatTvBtY3F1DrCrUKE5Kkn770M','e':'AQAB','kid':'ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA','kty':'RSA','n':'wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw','p':'7enorp9Pm9XSHaCvQyENcvdU99WCPbnp8vc0KnY_0g9UdX4ZDH07JwKu6DQEwfmUA1qspC-e_KFWTl3x0-I2eJRnHjLOoLrTjrVSBRhBMGEH5PvtZTTThnIY2LReH-6EhceGvcsJ_MhNDUEZLykiH1OnKhmRuvSdhi8oiETqtPE','q':'0CBLGi_kRPLqI8yfVkpBbA9zkCAshgrWWn9hsq6a7Zl2LcLaLBRUxH0q1jWnXgeJh9o5v8sYGXwhbrmuypw7kJ0uA3OgEzSsNvX5Ay3R9sNel-3Mqm8Me5OfWWvmTEBOci8RwHstdR-7b9ZT13jk-dsZI7OlV_uBja1ny9Nz9ts','qi':'pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4'}";
+        """
+        {
+            "d":"GmiaucNIzdvsEzGjZjd43SDToy1pz-Ph-shsOUXXh-dsYNGftITGerp8bO1iryXh_zUEo8oDK3r1y4klTonQ6bLsWw4ogjLPmL3yiqsoSjJa1G2Ymh_RY_sFZLLXAcrmpbzdWIAkgkHSZTaliL6g57vA7gxvd8L4s82wgGer_JmURI0ECbaCg98JVS0Srtf9GeTRHoX4foLWKc1Vq6NHthzqRMLZe-aRBNU9IMvXNd7kCcIbHCM3GTD_8cFj135nBPP2HOgC_ZXI1txsEf-djqJj8W5vaM7ViKU28IDv1gZGH3CatoysYx6jv1XJVvb2PH8RbFKbJmeyUm3Wvo-rgQ",
+            "dp":"YNjVBTCIwZD65WCht5ve06vnBLP_Po1NtL_4lkholmPzJ5jbLYBU8f5foNp8DVJBdFQW7wcLmx85-NC5Pl1ZeyA-Ecbw4fDraa5Z4wUKlF0LT6VV79rfOF19y8kwf6MigyrDqMLcH_CRnRGg5NfDsijlZXffINGuxg6wWzhiqqE",
+            "dq":"LfMDQbvTFNngkZjKkN2CBh5_MBG6Yrmfy4kWA8IC2HQqID5FtreiY2MTAwoDcoINfh3S5CItpuq94tlB2t-VUv8wunhbngHiB5xUprwGAAnwJ3DL39D2m43i_3YP-UO1TgZQUAOh7Jrd4foatpatTvBtY3F1DrCrUKE5Kkn770M",
+            "e":"AQAB",
+            "kid":"ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA",
+            "kty":"RSA",
+            "n":"wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw",
+            "p":"7enorp9Pm9XSHaCvQyENcvdU99WCPbnp8vc0KnY_0g9UdX4ZDH07JwKu6DQEwfmUA1qspC-e_KFWTl3x0-I2eJRnHjLOoLrTjrVSBRhBMGEH5PvtZTTThnIY2LReH-6EhceGvcsJ_MhNDUEZLykiH1OnKhmRuvSdhi8oiETqtPE",
+            "q":"0CBLGi_kRPLqI8yfVkpBbA9zkCAshgrWWn9hsq6a7Zl2LcLaLBRUxH0q1jWnXgeJh9o5v8sYGXwhbrmuypw7kJ0uA3OgEzSsNvX5Ay3R9sNel-3Mqm8Me5OfWWvmTEBOci8RwHstdR-7b9ZT13jk-dsZI7OlV_uBja1ny9Nz9ts",
+            "qi":"pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4"
+        }
+        """;
     
     private static SigningCredentials Credential = new (new JsonWebKey(RsaKey), "RS256");
 

--- a/samples/Worker/Worker.csproj
+++ b/samples/Worker/Worker.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.21.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/WorkerDI/ClientAssertionService.cs
+++ b/samples/WorkerDI/ClientAssertionService.cs
@@ -18,8 +18,21 @@ public class ClientAssertionService : IClientAssertionService
     private readonly IOptionsSnapshot<ClientCredentialsClient> _options;
 
     private static string RsaKey =
-        "{'d':'GmiaucNIzdvsEzGjZjd43SDToy1pz-Ph-shsOUXXh-dsYNGftITGerp8bO1iryXh_zUEo8oDK3r1y4klTonQ6bLsWw4ogjLPmL3yiqsoSjJa1G2Ymh_RY_sFZLLXAcrmpbzdWIAkgkHSZTaliL6g57vA7gxvd8L4s82wgGer_JmURI0ECbaCg98JVS0Srtf9GeTRHoX4foLWKc1Vq6NHthzqRMLZe-aRBNU9IMvXNd7kCcIbHCM3GTD_8cFj135nBPP2HOgC_ZXI1txsEf-djqJj8W5vaM7ViKU28IDv1gZGH3CatoysYx6jv1XJVvb2PH8RbFKbJmeyUm3Wvo-rgQ','dp':'YNjVBTCIwZD65WCht5ve06vnBLP_Po1NtL_4lkholmPzJ5jbLYBU8f5foNp8DVJBdFQW7wcLmx85-NC5Pl1ZeyA-Ecbw4fDraa5Z4wUKlF0LT6VV79rfOF19y8kwf6MigyrDqMLcH_CRnRGg5NfDsijlZXffINGuxg6wWzhiqqE','dq':'LfMDQbvTFNngkZjKkN2CBh5_MBG6Yrmfy4kWA8IC2HQqID5FtreiY2MTAwoDcoINfh3S5CItpuq94tlB2t-VUv8wunhbngHiB5xUprwGAAnwJ3DL39D2m43i_3YP-UO1TgZQUAOh7Jrd4foatpatTvBtY3F1DrCrUKE5Kkn770M','e':'AQAB','kid':'ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA','kty':'RSA','n':'wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw','p':'7enorp9Pm9XSHaCvQyENcvdU99WCPbnp8vc0KnY_0g9UdX4ZDH07JwKu6DQEwfmUA1qspC-e_KFWTl3x0-I2eJRnHjLOoLrTjrVSBRhBMGEH5PvtZTTThnIY2LReH-6EhceGvcsJ_MhNDUEZLykiH1OnKhmRuvSdhi8oiETqtPE','q':'0CBLGi_kRPLqI8yfVkpBbA9zkCAshgrWWn9hsq6a7Zl2LcLaLBRUxH0q1jWnXgeJh9o5v8sYGXwhbrmuypw7kJ0uA3OgEzSsNvX5Ay3R9sNel-3Mqm8Me5OfWWvmTEBOci8RwHstdR-7b9ZT13jk-dsZI7OlV_uBja1ny9Nz9ts','qi':'pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4'}";
-    
+        """
+        {
+            "d":"GmiaucNIzdvsEzGjZjd43SDToy1pz-Ph-shsOUXXh-dsYNGftITGerp8bO1iryXh_zUEo8oDK3r1y4klTonQ6bLsWw4ogjLPmL3yiqsoSjJa1G2Ymh_RY_sFZLLXAcrmpbzdWIAkgkHSZTaliL6g57vA7gxvd8L4s82wgGer_JmURI0ECbaCg98JVS0Srtf9GeTRHoX4foLWKc1Vq6NHthzqRMLZe-aRBNU9IMvXNd7kCcIbHCM3GTD_8cFj135nBPP2HOgC_ZXI1txsEf-djqJj8W5vaM7ViKU28IDv1gZGH3CatoysYx6jv1XJVvb2PH8RbFKbJmeyUm3Wvo-rgQ",
+            "dp":"YNjVBTCIwZD65WCht5ve06vnBLP_Po1NtL_4lkholmPzJ5jbLYBU8f5foNp8DVJBdFQW7wcLmx85-NC5Pl1ZeyA-Ecbw4fDraa5Z4wUKlF0LT6VV79rfOF19y8kwf6MigyrDqMLcH_CRnRGg5NfDsijlZXffINGuxg6wWzhiqqE",
+            "dq":"LfMDQbvTFNngkZjKkN2CBh5_MBG6Yrmfy4kWA8IC2HQqID5FtreiY2MTAwoDcoINfh3S5CItpuq94tlB2t-VUv8wunhbngHiB5xUprwGAAnwJ3DL39D2m43i_3YP-UO1TgZQUAOh7Jrd4foatpatTvBtY3F1DrCrUKE5Kkn770M",
+            "e":"AQAB",
+            "kid":"ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA",
+            "kty":"RSA",
+            "n":"wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw",
+            "p":"7enorp9Pm9XSHaCvQyENcvdU99WCPbnp8vc0KnY_0g9UdX4ZDH07JwKu6DQEwfmUA1qspC-e_KFWTl3x0-I2eJRnHjLOoLrTjrVSBRhBMGEH5PvtZTTThnIY2LReH-6EhceGvcsJ_MhNDUEZLykiH1OnKhmRuvSdhi8oiETqtPE",
+            "q":"0CBLGi_kRPLqI8yfVkpBbA9zkCAshgrWWn9hsq6a7Zl2LcLaLBRUxH0q1jWnXgeJh9o5v8sYGXwhbrmuypw7kJ0uA3OgEzSsNvX5Ay3R9sNel-3Mqm8Me5OfWWvmTEBOci8RwHstdR-7b9ZT13jk-dsZI7OlV_uBja1ny9Nz9ts",
+            "qi":"pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4"
+        }
+        """;
+
     private static SigningCredentials Credential = new (new JsonWebKey(RsaKey), "RS256");
 
     public ClientAssertionService(IOptionsSnapshot<ClientCredentialsClient> options)

--- a/samples/WorkerDI/ClientCredentialsClientConfigureOptions.cs
+++ b/samples/WorkerDI/ClientCredentialsClientConfigureOptions.cs
@@ -19,7 +19,7 @@ public class ClientCredentialsClientConfigureOptions : IConfigureNamedOptions<Cl
         throw new System.NotImplementedException();
     }
 
-    public void Configure(string name, ClientCredentialsClient options)
+    public void Configure(string? name, ClientCredentialsClient options)
     {
         if (name == "demo.jwt")
         {

--- a/samples/WorkerDI/WorkerDI.csproj
+++ b/samples/WorkerDI/WorkerDI.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.21.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
@@ -87,53 +87,21 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
                 return new UserToken() { Error = "No tokens in properties" };
             }
 
-            var tokenName = $"{TokenPrefix}{OpenIdConnectParameterNames.AccessToken}";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                tokenName += $"::{parameters.Resource}";
-            }
-            var tokenTypeName = $"{TokenPrefix}{OpenIdConnectParameterNames.TokenType}";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                tokenTypeName += $"::{parameters.Resource}";
-            }
-            var dpopKeyName = $"{TokenPrefix}{DPoPKeyName}";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                dpopKeyName += $"::{parameters.Resource}";
-            }
-            var expiresName = $"{TokenPrefix}expires_at";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                expiresName += $"::{parameters.Resource}";
-            }
-            const string refreshTokenName = $"{TokenPrefix}{OpenIdConnectParameterNames.RefreshToken}";
+            var tokenName = NamePrefixAndResourceSuffix(OpenIdConnectParameterNames.AccessToken, parameters);
+            var tokenTypeName = NamePrefixAndResourceSuffix(OpenIdConnectParameterNames.TokenType, parameters);
+            var dpopKeyName = NamePrefixAndResourceSuffix(DPoPKeyName, parameters);
+            var expiresName = NamePrefixAndResourceSuffix("expires_at", parameters);
+            
+            // Note that we are not including the the resource suffix because there is no per-resource refresh token
+            var refreshTokenName = NamePrefix(OpenIdConnectParameterNames.RefreshToken);
 
-            string? refreshToken = null;
-            string? accessToken = null;
-            string? accessTokenType = null;
-            string? dpopKey = null;
-            string? expiresAt = null;
+            var appendChallengeScheme = AppendChallengeSchemeToTokenNames(parameters);
 
-            if (AppendChallengeSchemeToTokenNames(parameters))
-            {
-                refreshToken = tokens
-                        .SingleOrDefault(t => t.Key == $"{refreshTokenName}||{parameters.ChallengeScheme}").Value;
-                accessToken = tokens.SingleOrDefault(t => t.Key == $"{tokenName}||{parameters.ChallengeScheme}")
-                    .Value;
-                accessTokenType = tokens.SingleOrDefault(t => t.Key == $"{tokenTypeName}||{parameters.ChallengeScheme}")
-                    .Value;
-                dpopKey = tokens.SingleOrDefault(t => t.Key == $"{dpopKeyName}||{parameters.ChallengeScheme}")
-                    .Value;
-                expiresAt = tokens.SingleOrDefault(t => t.Key == $"{expiresName}||{parameters.ChallengeScheme}")
-                    .Value;
-            }
-
-            refreshToken ??= tokens.SingleOrDefault(t => t.Key == $"{refreshTokenName}").Value;
-            accessToken ??= tokens.SingleOrDefault(t => t.Key == $"{tokenName}").Value;
-            accessTokenType ??= tokens.SingleOrDefault(t => t.Key == $"{tokenTypeName}").Value;
-            dpopKey ??= tokens.SingleOrDefault(t => t.Key == $"{dpopKeyName}").Value;
-            expiresAt ??= tokens.SingleOrDefault(t => t.Key == $"{expiresName}").Value;
+            var accessToken = GetTokenValue(tokens, tokenName, appendChallengeScheme, parameters);
+            var accessTokenType = GetTokenValue(tokens, tokenTypeName, appendChallengeScheme, parameters);
+            var dpopKey = GetTokenValue(tokens, dpopKeyName, appendChallengeScheme, parameters);
+            var expiresAt = GetTokenValue(tokens, expiresName, appendChallengeScheme, parameters);
+            var refreshToken = GetTokenValue(tokens, refreshTokenName, appendChallengeScheme, parameters);
 
             DateTimeOffset dtExpires = DateTimeOffset.MaxValue;
             if (expiresAt != null)
@@ -150,6 +118,51 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
                 Expiration = dtExpires
             };
         }
+
+        // If we are using the challenge scheme, we try to get the token 2 ways
+        // (with and without the suffix). This is necessary because ASP.NET
+        // itself does not set the suffix, so we might not have one at all.
+        private static string? GetTokenValue(List<KeyValuePair<string, string?>> tokens, string key, bool appendChallengeScheme, UserTokenRequestParameters parameters)
+        {
+            string? token = null;
+
+            if(appendChallengeScheme)
+            {
+                var scheme = parameters.ChallengeScheme;
+                token = GetTokenValue(tokens, ChallengeSuffix(key, scheme!));
+            }
+
+            if (token.IsMissing())
+            {
+                token = GetTokenValue(tokens, key);
+            }
+            return token;
+        }
+        
+        private static string? GetTokenValue(List<KeyValuePair<string, string?>> tokens, string key)
+        {
+            return tokens.SingleOrDefault(t => t.Key == key).Value;
+        }
+
+        /// Adds the .Token. prefix to the token name and, if the resource
+        /// parameter was included, the suffix marking this token as
+        /// per-resource.
+        private static string NamePrefixAndResourceSuffix(string type, UserTokenRequestParameters parameters) 
+        {
+            var result = NamePrefix(type);
+            if(!string.IsNullOrEmpty(parameters.Resource))
+            {
+                result = ResourceSuffix(result, parameters.Resource);
+            }
+            return result;
+        }
+
+        private static string NamePrefix(string name) => $"{TokenPrefix}{name}";
+
+        private static string ResourceSuffix(string name, string resource) => $"{name}::{resource}";
+
+        private static string ChallengeSuffix(string name, string challengeScheme) => $"{name}||{challengeScheme}";
+
 
         /// <inheritdoc/>
         public async Task StoreTokenAsync(
@@ -174,35 +187,22 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
             // in case you want to filter certain claims before re-issuing the authentication session
             var transformedPrincipal = await FilterPrincipalAsync(result.Principal!).ConfigureAwait(false);
 
-            var tokenName = $"{TokenPrefix}{OpenIdConnectParameterNames.AccessToken}";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                tokenName += $"::{parameters.Resource}";
-            }
-            var tokenTypeName = $"{TokenPrefix}{OpenIdConnectParameterNames.TokenType}";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                tokenTypeName += $"::{parameters.Resource}";
-            }
-            var dpopKeyName = $"{TokenPrefix}{DPoPKeyName}";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                dpopKeyName += $"::{parameters.Resource}";
-            }
-            var expiresName = $"{TokenPrefix}expires_at";
-            if (!string.IsNullOrEmpty(parameters.Resource))
-            {
-                expiresName += $"::{parameters.Resource}";
-            }
-            var refreshTokenName = $"{OpenIdConnectParameterNames.RefreshToken}";
-
+            var tokenName = NamePrefixAndResourceSuffix(OpenIdConnectParameterNames.AccessToken, parameters);
+            var tokenTypeName = NamePrefixAndResourceSuffix(OpenIdConnectParameterNames.TokenType, parameters);
+            var dpopKeyName = NamePrefixAndResourceSuffix(DPoPKeyName, parameters);
+            var expiresName = NamePrefixAndResourceSuffix("expires_at", parameters);
+            
+            // Note that we are not including the the resource suffix because there is no per-resource refresh token
+            var refreshTokenName = NamePrefix(OpenIdConnectParameterNames.RefreshToken);
+            
             if (AppendChallengeSchemeToTokenNames(parameters))
             {
-                refreshTokenName += $"||{parameters.ChallengeScheme}";
-                tokenName += $"||{parameters.ChallengeScheme}";
-                tokenTypeName += $"||{parameters.ChallengeScheme}";
-                dpopKeyName += $"||{parameters.ChallengeScheme}";
-                expiresName += $"||{parameters.ChallengeScheme}";
+                string challengeScheme = parameters.ChallengeScheme!;
+                tokenName = ChallengeSuffix(tokenName, challengeScheme);
+                tokenTypeName = ChallengeSuffix(tokenTypeName, challengeScheme);
+                dpopKeyName = ChallengeSuffix(dpopKeyName, challengeScheme);
+                expiresName = ChallengeSuffix(expiresName, challengeScheme);
+                refreshTokenName = ChallengeSuffix(refreshTokenName, challengeScheme);
             }
 
             result.Properties!.Items[tokenName] = token.AccessToken;
@@ -273,7 +273,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
         /// <returns></returns>
         protected virtual bool AppendChallengeSchemeToTokenNames(UserTokenRequestParameters parameters)
         {
-            return _options.UseChallengeSchemeScopedTokens && !string.IsNullOrEmpty(parameters!.ChallengeScheme);
+            return _options.UseChallengeSchemeScopedTokens && !string.IsNullOrEmpty(parameters.ChallengeScheme);
         }
     }
 }

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
@@ -192,7 +192,8 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
             var dpopKeyName = NamePrefixAndResourceSuffix(DPoPKeyName, parameters);
             var expiresName = NamePrefixAndResourceSuffix("expires_at", parameters);
             
-            // Note that we are not including the the resource suffix because there is no per-resource refresh token
+            // Note that we are not including the resource suffix because there
+            // is no per-resource refresh token
             var refreshTokenName = NamePrefix(OpenIdConnectParameterNames.RefreshToken);
             
             if (AppendChallengeSchemeToTokenNames(parameters))
@@ -215,10 +216,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
 
             if (token.RefreshToken != null)
             {
-                if (!result.Properties.UpdateTokenValue(refreshTokenName, token.RefreshToken))
-                {
-                    result.Properties.Items[$"{TokenPrefix}{refreshTokenName}"] = token.RefreshToken;
-                }
+                result.Properties.Items[refreshTokenName] = token.RefreshToken;
             }
 
             var options = _contextAccessor!.HttpContext!.RequestServices.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>();

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication;
@@ -235,7 +235,10 @@ namespace Duende.AccessTokenManagement.OpenIdConnect
             }
 
             result.Properties.Items.Remove(TokenNamesKey);
-            result.Properties.Items.Add(new KeyValuePair<string, string?>(TokenNamesKey, string.Join(";", result.Properties.Items.Select(t => t.Key).ToList())));
+            var tokenNames = result.Properties.Items
+                .Where(item => item.Key.StartsWith(TokenPrefix))
+                .Select(item => item.Key.Substring(TokenPrefix.Length));
+            result.Properties.Items.Add(new KeyValuePair<string, string?>(TokenNamesKey, string.Join(";", tokenNames)));
 
             await _contextAccessor.HttpContext.SignInAsync(parameters.SignInScheme, transformedPrincipal, result.Properties).ConfigureAwait(false);
 

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/ConfigureOpenIdConnectClientCredentialsOptions.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/ConfigureOpenIdConnectClientCredentialsOptions.cs
@@ -32,8 +32,9 @@ public class ConfigureOpenIdConnectClientCredentialsOptions : IConfigureNamedOpt
     { }
 
     /// <inheritdoc />
-    public void Configure(string name, ClientCredentialsClient options)
+    public void Configure(string? name, ClientCredentialsClient options)
     {
+        if (name.IsMissing()) return;
         if (!name.StartsWith(OpenIdConnectTokenManagementDefaults.ClientCredentialsClientNamePrefix)) return;
         
         string? scheme = null;

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/ConfigureOpenIdConnectOptions.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/ConfigureOpenIdConnectOptions.cs
@@ -63,7 +63,7 @@ public class ConfigureOpenIdConnectOptions : IConfigureNamedOptions<OpenIdConnec
     }
 
     /// <inheritdoc/>
-    public void Configure(string name, OpenIdConnectOptions options)
+    public void Configure(string? name, OpenIdConnectOptions options)
     {
         if (_configScheme == name)
         {

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/Duende.AccessTokenManagement.OpenIdConnect.csproj
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/Duende.AccessTokenManagement.OpenIdConnect.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
 
         <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/Duende.AccessTokenManagement.OpenIdConnect.csproj
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/Duende.AccessTokenManagement.OpenIdConnect.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
@@ -11,7 +11,8 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
+
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
 
         <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/UserAccessTokenManagementService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/UserAccessTokenManagementService.cs
@@ -19,7 +19,11 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
 {
     private readonly IUserTokenRequestSynchronization _sync;
     private readonly IUserTokenStore _userAccessTokenStore;
+#if NET8_0_OR_GREATER
     private readonly TimeProvider _clock;
+#else
+    private readonly ISystemClock _clock;
+#endif
     private readonly UserTokenManagementOptions _options;
     private readonly IUserTokenEndpointService _tokenEndpointService;
     private readonly ILogger<UserAccessAccessTokenManagementService> _logger;
@@ -36,7 +40,11 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
     public UserAccessAccessTokenManagementService(
         IUserTokenRequestSynchronization sync,
         IUserTokenStore userAccessTokenStore,
+#if NET8_0_OR_GREATER
         TimeProvider clock,
+#else
+        ISystemClock clock,
+#endif
         IOptions<UserTokenManagementOptions> options,
         IUserTokenEndpointService tokenEndpointService,
         ILogger<UserAccessAccessTokenManagementService> logger)
@@ -92,7 +100,12 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
         }
 
         var dtRefresh = userToken.Expiration.Subtract(_options.RefreshBeforeExpiration);
-        if (dtRefresh < _clock.GetUtcNow() || parameters.ForceRenewal || needsRenewal)
+#if NET8_0_OR_GREATER
+        var utcNow = _clock.GetUtcNow();
+#else
+        var utcNow = _clock.UtcNow;
+#endif
+        if (dtRefresh < utcNow || parameters.ForceRenewal || needsRenewal)
         {
             _logger.LogDebug("Token for user {user} needs refreshing.", userName);
 

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/UserAccessTokenManagementService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/UserAccessTokenManagementService.cs
@@ -19,7 +19,7 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
 {
     private readonly IUserTokenRequestSynchronization _sync;
     private readonly IUserTokenStore _userAccessTokenStore;
-    private readonly ISystemClock _clock;
+    private readonly TimeProvider _clock;
     private readonly UserTokenManagementOptions _options;
     private readonly IUserTokenEndpointService _tokenEndpointService;
     private readonly ILogger<UserAccessAccessTokenManagementService> _logger;
@@ -36,7 +36,7 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
     public UserAccessAccessTokenManagementService(
         IUserTokenRequestSynchronization sync,
         IUserTokenStore userAccessTokenStore,
-        ISystemClock clock,
+        TimeProvider clock,
         IOptions<UserTokenManagementOptions> options,
         IUserTokenEndpointService tokenEndpointService,
         ILogger<UserAccessAccessTokenManagementService> logger)
@@ -92,7 +92,7 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
         }
 
         var dtRefresh = userToken.Expiration.Subtract(_options.RefreshBeforeExpiration);
-        if (dtRefresh < _clock.UtcNow || parameters.ForceRenewal || needsRenewal)
+        if (dtRefresh < _clock.GetUtcNow() || parameters.ForceRenewal || needsRenewal)
         {
             _logger.LogDebug("Token for user {user} needs refreshing.", userName);
 

--- a/src/Duende.AccessTokenManagement/DefaultDPoPProofService.cs
+++ b/src/Duende.AccessTokenManagement/DefaultDPoPProofService.cs
@@ -48,33 +48,24 @@ public class DefaultDPoPProofService : IDPoPProofService
 
         // jwk: representing the public key chosen by the client, in JSON Web Key (JWK) [RFC7517] format,
         // as defined in Section 4.1.3 of [RFC7515]. MUST NOT contain a private key.
-        object jwk;
+        Dictionary<string, string> jwk;
         if (string.Equals(jsonWebKey.Kty, JsonWebAlgorithmsKeyTypes.EllipticCurve))
         {
-            jwk = new
+            jwk = new()
             {
-                kty = jsonWebKey.Kty,
-                x = jsonWebKey.X,
-                y = jsonWebKey.Y,
-                crv = jsonWebKey.Crv
+                { "kty", jsonWebKey.Kty },
+                { "x", jsonWebKey.X },
+                { "y", jsonWebKey.Y },
+                { "crv", jsonWebKey.Crv }
             };
-
-
-            //             jwk = new()
-            // {
-            //     { "kty", jsonWebKey.Kty },
-            //     { "x", jsonWebKey.X },
-            //     { "y", jsonWebKey.Y },
-            //     { "crv", jsonWebKey.Crv }
-            // };
         }
         else if (string.Equals(jsonWebKey.Kty, JsonWebAlgorithmsKeyTypes.RSA))
         {
-            jwk = new
+            jwk = new()
             {
-                kty = jsonWebKey.Kty,
-                e = jsonWebKey.E,
-                n = jsonWebKey.N
+                { "kty", jsonWebKey.Kty },
+                { "e", jsonWebKey.E },
+                { "n", jsonWebKey.N }
             };
         }
         else

--- a/src/Duende.AccessTokenManagement/DefaultDPoPProofService.cs
+++ b/src/Duende.AccessTokenManagement/DefaultDPoPProofService.cs
@@ -58,6 +58,15 @@ public class DefaultDPoPProofService : IDPoPProofService
                 y = jsonWebKey.Y,
                 crv = jsonWebKey.Crv
             };
+
+
+            //             jwk = new()
+            // {
+            //     { "kty", jsonWebKey.Kty },
+            //     { "x", jsonWebKey.X },
+            //     { "y", jsonWebKey.Y },
+            //     { "crv", jsonWebKey.Crv }
+            // };
         }
         else if (string.Equals(jsonWebKey.Kty, JsonWebAlgorithmsKeyTypes.RSA))
         {

--- a/src/Duende.AccessTokenManagement/Duende.AccessTokenManagement.csproj
+++ b/src/Duende.AccessTokenManagement/Duende.AccessTokenManagement.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
@@ -16,12 +16,11 @@
         <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 
-        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     </ItemGroup>
-
 </Project>

--- a/src/Duende.AccessTokenManagement/Duende.AccessTokenManagement.csproj
+++ b/src/Duende.AccessTokenManagement/Duende.AccessTokenManagement.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
@@ -11,17 +11,17 @@
         
 
     <ItemGroup>
-        <PackageReference Include="IdentityModel" Version="6.1.0" />
+        <PackageReference Include="IdentityModel" Version="6.2.0" />
         
         <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 
-        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/test/Tests/Framework/ApiHost.cs
+++ b/test/Tests/Framework/ApiHost.cs
@@ -14,11 +14,12 @@ public class ApiHost : GenericHost
     private readonly IdentityServerHost _identityServerHost;
     public event Action<Microsoft.AspNetCore.Http.HttpContext> ApiInvoked = ctx => { };
         
-    public ApiHost(IdentityServerHost identityServerHost, string scope, string baseAddress = "https://api") 
+    public ApiHost(IdentityServerHost identityServerHost, string scope, string baseAddress = "https://api", string resource = "urn:api") 
         : base(baseAddress)
     {
         _identityServerHost = identityServerHost;
         _identityServerHost.ApiScopes.Add(new ApiScope(scope));
+        _identityServerHost.ApiResources.Add(new ApiResource(resource));
 
         OnConfigureServices += ConfigureServices;
         OnConfigure += Configure;

--- a/test/Tests/Framework/AppHost.cs
+++ b/test/Tests/Framework/AppHost.cs
@@ -7,6 +7,8 @@ using System.Net;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using RichardSzalay.MockHttp;
+using Duende.AccessTokenManagement.OpenIdConnect;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Duende.AccessTokenManagement.Tests;
 
@@ -92,7 +94,10 @@ public class AppHost : GenericHost
             });
 
         services.AddDistributedMemoryCache();
-        services.AddOpenIdConnectAccessTokenManagement();
+        services.AddOpenIdConnectAccessTokenManagement(opt =>
+        {
+            opt.UseChallengeSchemeScopedTokens = true;
+        });
 
     }
 
@@ -120,6 +125,15 @@ public class AppHost : GenericHost
             endpoints.MapGet("/user_token", async context =>
             {
                 var token = await context.GetUserAccessTokenAsync();
+                await context.Response.WriteAsJsonAsync(token);
+            });
+
+            endpoints.MapGet("/user_token_with_resource/{resource}", async (string resource, HttpContext context) =>
+            {
+                var token = await context.GetUserAccessTokenAsync(new UserTokenRequestParameters
+                {
+                    Resource = resource
+                });
                 await context.Response.WriteAsJsonAsync(token);
             });
             

--- a/test/Tests/Framework/GenericHost.cs
+++ b/test/Tests/Framework/GenericHost.cs
@@ -61,7 +61,7 @@ public class GenericHost
                 {
                     if (HostAssembly is not null)
                     {
-                        context.HostingEnvironment.ApplicationName = HostAssembly.GetName().Name;
+                        context.HostingEnvironment.ApplicationName = HostAssembly.GetName().Name!;
                     }
                 });
 

--- a/test/Tests/Framework/IdentityServerHost.cs
+++ b/test/Tests/Framework/IdentityServerHost.cs
@@ -74,7 +74,7 @@ public class IdentityServerHost : GenericHost
 
                 var signOutContext = await interaction.GetLogoutContextAsync(logoutId);
                     
-                context.Response.Redirect(signOutContext.PostLogoutRedirectUri);
+                context.Response.Redirect(signOutContext.PostLogoutRedirectUri ?? "/");
             });
         });
     }

--- a/test/Tests/Framework/IdentityServerHost.cs
+++ b/test/Tests/Framework/IdentityServerHost.cs
@@ -31,6 +31,11 @@ public class IdentityServerHost : GenericHost
     };
     
     public List<ApiScope> ApiScopes { get; set; } = new();
+    public List<ApiResource> ApiResources { get; set; } = new()
+    {
+        new ApiResource("urn:api1"),
+        new ApiResource("urn:api2")
+    };
 
     private void ConfigureServices(IServiceCollection services)
     {
@@ -47,6 +52,7 @@ public class IdentityServerHost : GenericHost
             })
             .AddInMemoryClients(Clients)
             .AddInMemoryIdentityResources(IdentityResources)
+            .AddInMemoryApiResources(ApiResources)
             .AddInMemoryApiScopes(ApiScopes);
     }
 

--- a/test/Tests/Framework/TestDistributedCache.cs
+++ b/test/Tests/Framework/TestDistributedCache.cs
@@ -4,14 +4,14 @@ namespace Duende.AccessTokenManagement.Tests;
 
 internal class TestDistributedCache : IDistributedCache
 {
-    private readonly Dictionary<string, byte[]> _cache = new();
+    private readonly Dictionary<string, byte[]?> _cache = new();
     
-    public byte[] Get(string key)
+    public byte[]? Get(string key)
     {
         return _cache[key];
     }
 
-    public Task<byte[]> GetAsync(string key, CancellationToken token = new CancellationToken())
+    public Task<byte[]?> GetAsync(string key, CancellationToken token = new CancellationToken())
     {
         return Task.FromResult(_cache[key]);
     }

--- a/test/Tests/Framework/TestLoggerProvider.cs
+++ b/test/Tests/Framework/TestLoggerProvider.cs
@@ -23,7 +23,9 @@ public class TestLoggerProvider : ILoggerProvider
         }
 
         public IDisposable BeginScope<TState>(TState state)
+#if NET8_0_OR_GREATER
             where TState : notnull
+#endif
         {
             return this;
         }

--- a/test/Tests/Framework/TestLoggerProvider.cs
+++ b/test/Tests/Framework/TestLoggerProvider.cs
@@ -23,6 +23,7 @@ public class TestLoggerProvider : ILoggerProvider
         }
 
         public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
         {
             return this;
         }

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -11,11 +11,11 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
         
-        <PackageReference Include="Duende.IdentityServer" Version="6.3.0-preview.1.1" />
+        <PackageReference Include="Duende.IdentityServer" Version="7.0.0-preview.2" />
         
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -11,11 +11,11 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"/>
+        <PackageReference Include="Microsoft.AspNetCore.TestHost"/>
         
-        <PackageReference Include="Duende.IdentityServer" Version="7.0.0-preview.2" />
+        <PackageReference Include="Duende.IdentityServer" Version="$(IdentityServerVersion)" />
         
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Tests/UserTokenManagementTests.cs
+++ b/test/Tests/UserTokenManagementTests.cs
@@ -269,4 +269,84 @@ public class UserTokenManagementTests : IntegrationTestBase
         token.RefreshToken.ShouldBe("refreshed2_refresh_token");
         token.Expiration.ShouldNotBe(DateTimeOffset.MaxValue);
     }
+
+    [Fact]
+    public async Task Resources_get_distinct_tokens()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        AppHost.IdentityServerHttpHandler = mockHttp;
+        
+        // no resource specified
+        var initialTokenResponse = new
+        {
+            id_token = IdentityServerHost.CreateIdToken("1", "web"),
+            access_token = "access_token_without_resource",
+            token_type = "token_type",
+            expires_in = 3600,
+            refresh_token = "initial_refresh_token",
+        };
+        mockHttp.When("/connect/token")
+            .WithFormData("grant_type", "authorization_code")
+            .Respond("application/json", JsonSerializer.Serialize(initialTokenResponse));
+        
+        // resource 1 specified 
+        var resource1TokenResponse = new
+        {
+            access_token = "urn:api1_access_token",
+            token_type = "token_type1",
+            expires_in = 3600,
+            refresh_token = "initial_refresh_token",
+        };
+        mockHttp.When("/connect/token")
+            .WithFormData("grant_type", "refresh_token")
+            .WithFormData("resource", "urn:api1")
+            .Respond("application/json", JsonSerializer.Serialize(resource1TokenResponse));
+        
+        // resource 2 specified 
+        var resource2TokenResponse = new
+        {
+            access_token = "urn:api2_access_token",
+            token_type = "token_type1",
+            expires_in = 3600,
+            refresh_token = "initial_refresh_token",
+        };
+        mockHttp.When("/connect/token")
+            .WithFormData("grant_type", "refresh_token")
+            .WithFormData("resource", "urn:api2")
+            .Respond("application/json", JsonSerializer.Serialize(resource2TokenResponse));
+        
+        // setup host
+        await AppHost.InitializeAsync();
+        await AppHost.LoginAsync("alice");
+        
+        // first request - no resource
+        var response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token"));
+        var token = await response.Content.ReadFromJsonAsync<UserToken>();
+
+        token.ShouldNotBeNull();
+        token.IsError.ShouldBeFalse();
+        token.AccessToken.ShouldBe("access_token_without_resource");
+        token.RefreshToken.ShouldBe("initial_refresh_token");
+        token.Expiration.ShouldNotBe(DateTimeOffset.MaxValue);
+        
+        // second request - with resource api1
+        response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token_with_resource/urn:api1"));
+        token = await response.Content.ReadFromJsonAsync<UserToken>();
+
+        token.ShouldNotBeNull();
+        token.IsError.ShouldBeFalse();
+        token.AccessToken.ShouldBe("urn:api1_access_token");
+        token.RefreshToken.ShouldBe("initial_refresh_token"); // This doesn't change with resources!
+        token.Expiration.ShouldNotBe(DateTimeOffset.MaxValue);
+
+        // third request - with resource api2
+        response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token_with_resource/urn:api2"));
+        token = await response.Content.ReadFromJsonAsync<UserToken>();
+
+        token.ShouldNotBeNull();
+        token.IsError.ShouldBeFalse();
+        token.AccessToken.ShouldBe("urn:api2_access_token");
+        token.RefreshToken.ShouldBe("initial_refresh_token"); 
+        token.Expiration.ShouldNotBe(DateTimeOffset.MaxValue);
+    }
 }


### PR DESCRIPTION
This PR adds support for .NET 8 while keeping support for .NET 6. 

- Target both net6.0 and net8.0 in library projects and test project
- Use conditional compilation to use the .NET 8 TimeProvider when it is available
- Use conditional dependencies in proj file and a Directory.build.targets
- All samples updated to .NET 8
- DPoP bug fixed in .NET 8 (serialization of anonymous types is no longer supported)
  -  This fix is backwards compatible, since we just use a dictionary instead of an anonymous type, and that was supported by newtonsoft JSON serialization
- Polish DPoP sample with cleaner switch to toggle DPoP on and off, and hide links that don't make sense when DPoP is on (e.g., we don't both to have a "manual" sample of a DPoP request, so don't show that link when it is on)
- Fix up some nullability warnings 
- Update CI to use .NET 8 SDK