### PR TITLE
Scope property mapping in GetOpenIdConnectConfigurationAsync

### DIFF
--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectClientConfiguration.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectClientConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using System.Net.Http;
 
 namespace Duende.AccessTokenManagement.OpenIdConnect;
@@ -44,4 +45,9 @@ public class OpenIdConnectClientConfiguration
     /// The scheme name of the OIDC handler
     /// </summary>
     public string? Scheme { get; set; }
+
+    /// <summary>
+    /// Gets the list of permissions to request.
+    /// </summary>
+    public ICollection<string> Scope { get; set; } = new HashSet<string>();
 }

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
@@ -78,6 +78,8 @@ public class OpenIdConnectConfigurationService : IOpenIdConnectConfigurationServ
             ClientId = options.ClientId,
             ClientSecret = options.ClientSecret,
             HttpClient = options.Backchannel,
+
+            Scope = options.Scope
         };
     }
 }

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/UserTokenEndpointService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/UserTokenEndpointService.cs
@@ -64,7 +64,8 @@ public class UserTokenEndpointService : IUserTokenEndpointService
             ClientId = oidc.ClientId!,
             ClientSecret = oidc.ClientSecret,
             ClientCredentialStyle = _options.ClientCredentialStyle,
-            
+            Scope = string.Join(" ", oidc.Scope),
+
             RefreshToken = refreshToken
         };
         


### PR DESCRIPTION
**What issue does this PR address?**

When calling GetOpenIdConnectConfigurationAsync the resulting object doesn't contain the Scope property.
I added the necessary mapping, then used the new property in the HTTP request for RefreshAccessTokenAsync.

In relation with #43 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
