### PR TITLE
Configure openidconnectoptions with postconfigure ( support multiple dynamic openidconnect schemes )

### DIFF
--- a/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
         services.TryAddSingleton<IUserTokenRequestSynchronization, UserTokenRequestSynchronization>();
         services.TryAddTransient<IUserTokenEndpointService, UserTokenEndpointService>();
 
-        services.ConfigureOptions<ConfigureOpenIdConnectOptions>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, PostConfigureOpenIdConnectOptions>());
 
         return services;
     }


### PR DESCRIPTION
I have a use case where openidconnect schemes are added dynamically, this pull request replaces ConfigureOptions with a PostConfigureOpenIdConnectOptions to support this use case.

code snippet use case

```csharp
            ...

            // authority is a user supplied parameter

            IAuthenticationSchemeProvider _schemeProvider;
            IOptionsMonitorCache<OpenIdConnectOptions> _optionsCache;
            IEnumerable<IPostConfigureOptions<OpenIdConnectOptions>> _postConfigureOptions;

            ...

            _schemeProvider.AddScheme(new AuthenticationScheme(authority, authority, typeof(OpenIdConnectHandler)));
            OpenIdConnectOptions schemeOptions = new OpenIdConnectOptions
            {
                Authority = authority,
                ClientId = "clientid",
                ResponseType = "code",
                ResponseMode = "query",
                SaveTokens = true
            };
            foreach (var p in _postConfigureOptions)
            {
                p.PostConfigure(scheme, schemeOptions);
            } 
            _optionsCache.TryAdd(<authority>, schemeOptions);

           ...
```

AddOpenIdConnectAccessTokenManagement(...) should be called before  the first call to AddOpenIdConnect otherwise options.BackChannel is configured before the options.BackChannelHttpHandler which result  in DPoPProofHandler not being used.

