### PR TITLE
Remove space from closing a tag in Index.cshtml

### DIFF
--- a/samples/Web/Views/Home/Index.cshtml
+++ b/samples/Web/Views/Home/Index.cshtml
@@ -6,7 +6,7 @@
 
 @if (!Startup.UseDPoP)
 {
-    <a asp-controller="Home" asp-action = "CallApiAsClientExtensionMethod" > Extension method </a > 
+    <a asp-controller="Home" asp-action = "CallApiAsClientExtensionMethod" > Extension method </a> 
     @("|")
 }
 <a asp-controller="Home" asp-action="CallApiAsClientFactory">HTTP client factory</a> 


### PR DESCRIPTION
**What issue does this PR address?**

samples/Web/Views/Home/Index.cshtml contains an "a" tag that is not closed correctly. IDEs like Rider report an error because of this.

https://github.com/DuendeSoftware/Support/issues/1157
