### PR TITLE
Adds a specific exception when the clientId is empty.

### DIFF
--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
@@ -58,7 +58,7 @@ public class ClientCredentialsTokenEndpointService : IClientCredentialsTokenEndp
     {
         var client = _options.Get(clientName);
 
-        if (string.IsNullOrWhiteSpace(client.TokenEndpoint) || string.IsNullOrEmpty(client.ClientId))
+        if (string.IsNullOrWhiteSpace(client.TokenEndpoint))
         {
             throw new InvalidOperationException("unknown client");
         }

--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementBuilder.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementBuilder.cs
@@ -31,6 +31,13 @@ public class ClientCredentialsTokenManagementBuilder
     public ClientCredentialsTokenManagementBuilder AddClient(string name, Action<ClientCredentialsClient> configureOptions)
     {
         _services.Configure(name, configureOptions);
+        _services.PostConfigure<ClientCredentialsClient>(name, client =>
+        {
+            if (string.IsNullOrEmpty(client.ClientId))
+            {
+                throw new InvalidOperationException("ClientId must not be empty");
+            }
+        });
         return this;
     }
 }

--- a/test/Tests/ClientTokenManagementTests.cs
+++ b/test/Tests/ClientTokenManagementTests.cs
@@ -32,6 +32,35 @@ public class ClientTokenManagementTests
         await Should.ThrowAsync<InvalidOperationException>(action);
     }
 
+    [Fact]
+    public async Task Missing_client_id_throw_exception()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDistributedMemoryCache();
+        services.AddClientCredentialsTokenManagement()
+            .AddClient("test", client =>
+            {
+                client.TokenEndpoint = "https://as/connect/token";
+                client.ClientId = null;
+                client.ClientSecret = "client_secret";
+
+                client.Scope = "scope";
+                client.Resource = "resource";
+                client.Parameters.Add("audience", "audience");
+            });
+
+        var provider = services.BuildServiceProvider();
+        var sut = provider.GetRequiredService<IClientCredentialsTokenManagementService>();
+
+        async Task action()
+        {
+            var token = await sut.GetAccessTokenAsync("test");
+        }
+
+        await Should.ThrowAsync<InvalidOperationException>(action, "ClientId must not be empty");
+    }
+
     [Theory]
     [InlineData(ClientCredentialStyle.AuthorizationHeader)]
     [InlineData(ClientCredentialStyle.PostBody)]


### PR DESCRIPTION
**What issue does this PR address?**
The exception caused by an empty or null clientid is confusingly labeled "unknown client", which provides the impression that the named client hasn't been configured rather than that it was misconfigured. It is common for the client options to come from another dependency-injected object like an Option object, and this being misconfigured needs to be clearly distinguished from the client itself not being configured at all. 

Note that the added test passes without the changed behavior, because Shouldly doesn't seem to actually compare the exception message with the expected value. Would appreciate a look at this from someone more familiar with Shouldly.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
