### PR TITLE
Update wilson and framework dependencies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-        <FrameworkVersion>6.0.28</FrameworkVersion>
+        <FrameworkVersion>6.0.26</FrameworkVersion>
         <ExtensionsVersion>6.0.0</ExtensionsVersion>
         <WilsonVersion>6.35.0</WilsonVersion>
         <IdentityServerVersion>6.3.6</IdentityServerVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
-        <FrameworkVersion>8.0.3</FrameworkVersion>
+        <FrameworkVersion>8.0.1</FrameworkVersion>
         <ExtensionsVersion>8.0.0</ExtensionsVersion>
         <WilsonVersion>7.1.2</WilsonVersion>
         <IdentityServerVersion>7.0.4</IdentityServerVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,8 +2,8 @@
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
         <FrameworkVersion>8.0.3</FrameworkVersion>
         <ExtensionsVersion>8.0.0</ExtensionsVersion>
-        <WilsonVersion>7.3.1</WilsonVersion>
-        <IdentityServerVersion>7.0.3</IdentityServerVersion>
+        <WilsonVersion>7.1.2</WilsonVersion>
+        <IdentityServerVersion>7.0.4</IdentityServerVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0'">

--- a/samples/Worker/Worker.csproj
+++ b/samples/Worker/Worker.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.3.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/WorkerDI/WorkerDI.csproj
+++ b/samples/WorkerDI/WorkerDI.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.3.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -11,7 +11,6 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"/>
         <PackageReference Include="Microsoft.AspNetCore.TestHost"/>
         


### PR DESCRIPTION
This relaxes our dependencies on the wilson and framework dependencies.

Our priorities:

1. Avoid depending on a version that has a known security vulnerability
2. Avoid depending on a version that has a transitive dependency on a vulnerability
3. Use the same wilson version as the asp.net oidc handler
4. Depend on the minimum patch version that accomplishes that

Also, while here I'm updating the net6.0 build, we may (probably will) drop support for that in the 3.0 release.

