### PR TITLE
Drop support for .NET 6/7

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,14 +6,6 @@
         <IdentityServerVersion>7.0.4</IdentityServerVersion>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-        <FrameworkVersion>6.0.26</FrameworkVersion>
-        <ExtensionsVersion>6.0.0</ExtensionsVersion>
-        <WilsonVersion>6.35.0</WilsonVersion>
-        <IdentityServerVersion>6.3.6</IdentityServerVersion>
-    </PropertyGroup>
-
-
     <ItemGroup>
         <!-- ASP.NET -->
         <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(FrameworkVersion)" />

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/Duende.AccessTokenManagement.OpenIdConnect.csproj
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/Duende.AccessTokenManagement.OpenIdConnect.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/UserAccessTokenManagementService.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/UserAccessTokenManagementService.cs
@@ -19,11 +19,7 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
 {
     private readonly IUserTokenRequestSynchronization _sync;
     private readonly IUserTokenStore _userAccessTokenStore;
-#if NET8_0_OR_GREATER
     private readonly TimeProvider _clock;
-#else
-    private readonly ISystemClock _clock;
-#endif
     private readonly UserTokenManagementOptions _options;
     private readonly IUserTokenEndpointService _tokenEndpointService;
     private readonly ILogger<UserAccessAccessTokenManagementService> _logger;
@@ -40,11 +36,7 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
     public UserAccessAccessTokenManagementService(
         IUserTokenRequestSynchronization sync,
         IUserTokenStore userAccessTokenStore,
-#if NET8_0_OR_GREATER
         TimeProvider clock,
-#else
-        ISystemClock clock,
-#endif
         IOptions<UserTokenManagementOptions> options,
         IUserTokenEndpointService tokenEndpointService,
         ILogger<UserAccessAccessTokenManagementService> logger)
@@ -100,11 +92,7 @@ public class UserAccessAccessTokenManagementService : IUserTokenManagementServic
         }
 
         var dtRefresh = userToken.Expiration.Subtract(_options.RefreshBeforeExpiration);
-#if NET8_0_OR_GREATER
         var utcNow = _clock.GetUtcNow();
-#else
-        var utcNow = _clock.UtcNow;
-#endif
         if (dtRefresh < utcNow || parameters.ForceRenewal || needsRenewal)
         {
             _logger.LogDebug("Token for user {user} needs refreshing.", userName);

--- a/src/Duende.AccessTokenManagement/Duende.AccessTokenManagement.csproj
+++ b/src/Duende.AccessTokenManagement/Duende.AccessTokenManagement.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/test/Tests/Framework/TestLoggerProvider.cs
+++ b/test/Tests/Framework/TestLoggerProvider.cs
@@ -23,9 +23,7 @@ public class TestLoggerProvider : ILoggerProvider
         }
 
         public IDisposable BeginScope<TState>(TState state)
-#if NET8_0_OR_GREATER
             where TState : notnull
-#endif
         {
             return this;
         }

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
We are dropping support for .NET 6 and 7 in our next major release. .NET 6 will reach end-of-life soon, so for our next major release, we're dropping it. Same goes for .NET 7 (even sooner).