### PR TITLE
Add Authority to ClientCredentials options

### DIFF
--- a/samples/Worker/Program.cs
+++ b/samples/Worker/Program.cs
@@ -34,7 +34,7 @@ public class Program
                 services.AddClientCredentialsTokenManagement()
                     .AddClient("demo", client =>
                     {
-                        client.TokenEndpoint = "https://demo.duendesoftware.com/connect/token";
+                        client.Authority = "https://demo.duendesoftware.com/";
 
                         client.ClientId = "m2m.short";
                         client.ClientSecret = "secret";
@@ -43,8 +43,7 @@ public class Program
                     })
                     .AddClient("demo.dpop", client =>
                     {
-                        client.TokenEndpoint = "https://demo.duendesoftware.com/connect/token";
-                        //client.TokenEndpoint = "https://localhost:5001/connect/token";
+                        client.Authority = "https://demo.duendesoftware.com/";
 
                         client.ClientId = "m2m.dpop";
                         //client.ClientId = "m2m.dpop.nonce";
@@ -55,7 +54,7 @@ public class Program
                     })
                     .AddClient("demo.jwt", client =>
                     {
-                        client.TokenEndpoint = "https://demo.duendesoftware.com/connect/token";
+                        client.Authority = "https://demo.duendesoftware.com";
                         client.ClientId = "m2m.short.jwt";
 
                         client.Scope = "api";

--- a/samples/WorkerDI/ClientAssertionService.cs
+++ b/samples/WorkerDI/ClientAssertionService.cs
@@ -15,6 +15,7 @@ namespace WorkerService;
 
 public class ClientAssertionService : IClientAssertionService
 {
+    private readonly ITokenEndpointRetriever _tokenEndpoint;
     private readonly IOptionsMonitor<ClientCredentialsClient> _options;
 
     private static string RsaKey =
@@ -35,21 +36,22 @@ public class ClientAssertionService : IClientAssertionService
 
     private static SigningCredentials Credential = new (new JsonWebKey(RsaKey), "RS256");
 
-    public ClientAssertionService(IOptionsMonitor<ClientCredentialsClient> options)
+    public ClientAssertionService(ITokenEndpointRetriever tokenEndpoint, IOptionsMonitor<ClientCredentialsClient> options)
     {
+        _tokenEndpoint = tokenEndpoint;
         _options = options;
     }
 
-    public Task<ClientAssertion?> GetClientAssertionAsync(string? clientName = null, TokenRequestParameters? parameters = null)
+    public async Task<ClientAssertion?> GetClientAssertionAsync(string? clientName = null, TokenRequestParameters? parameters = null)
     {
         if (clientName == "demo.jwt")
         {
             var options = _options.Get(clientName);
-            
+
             var descriptor = new SecurityTokenDescriptor
             {
                 Issuer = options.ClientId,
-                Audience = options.TokenEndpoint,
+                Audience = await _tokenEndpoint.GetAsync(options),
                 Expires = DateTime.UtcNow.AddMinutes(1),
                 SigningCredentials = Credential,
 
@@ -64,13 +66,13 @@ public class ClientAssertionService : IClientAssertionService
             var handler = new JsonWebTokenHandler();
             var jwt = handler.CreateToken(descriptor);
 
-            return Task.FromResult<ClientAssertion?>(new ClientAssertion
+            return new ClientAssertion
             {
                 Type = OidcConstants.ClientAssertionTypes.JwtBearer,
                 Value = jwt
-            });
+            };
         }
 
-        return Task.FromResult<ClientAssertion?>(null);
+        return null;
     }
 }

--- a/samples/WorkerDI/ClientCredentialsClientConfigureOptions.cs
+++ b/samples/WorkerDI/ClientCredentialsClientConfigureOptions.cs
@@ -23,9 +23,7 @@ public class ClientCredentialsClientConfigureOptions : IConfigureNamedOptions<Cl
     {
         if (name == "demo.jwt")
         {
-            var disco = _cache.GetAsync().GetAwaiter().GetResult();
-
-            options.TokenEndpoint = disco.TokenEndpoint;
+            options.Authority = "https://demo.duendesoftware.com";
             options.ClientId = "m2m.short.jwt";
             options.Scope = "api";
         }

--- a/samples/WorkerDI/Program.cs
+++ b/samples/WorkerDI/Program.cs
@@ -37,7 +37,8 @@ public class Program
                 // alternative way to add a client
                 services.Configure<ClientCredentialsClient>("demo", client =>
                 {
-                    client.TokenEndpoint = "https://demo.duendesoftware.com/connect/token";
+                    client.Authority = "https://demo.duendesoftware.com/";
+                    // client.TokenEndpoint = "https://demo.duendesoftware.com/connect/token";
 
                     client.ClientId = "m2m.short";
                     client.ClientSecret = "secret";

--- a/src/Duende.AccessTokenManagement.OpenIdConnect/ConfigureOpenIdConnectClientCredentialsOptions.cs
+++ b/src/Duende.AccessTokenManagement.OpenIdConnect/ConfigureOpenIdConnectClientCredentialsOptions.cs
@@ -49,7 +49,8 @@ public class ConfigureOpenIdConnectClientCredentialsOptions : IConfigureNamedOpt
         }
         
         var oidc = _configurationService.GetOpenIdConnectConfigurationAsync(scheme).GetAwaiter().GetResult();
-            
+
+        options.Authority = oidc.Authority;
         options.TokenEndpoint = oidc.TokenEndpoint;
         options.ClientId = oidc.ClientId;
         options.ClientSecret = oidc.ClientSecret;

--- a/src/Duende.AccessTokenManagement/ClientCredentialsClient.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsClient.cs
@@ -1,8 +1,12 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net.Http;
 using IdentityModel.Client;
+using Microsoft.Extensions.Options;
 
 namespace Duende.AccessTokenManagement;
 
@@ -11,6 +15,12 @@ namespace Duende.AccessTokenManagement;
 /// </summary>
 public class ClientCredentialsClient
 {
+    /// <summary>
+    /// The address of the OAuth authority. If this is set, the TokenEndpoint
+    /// will be set using discovery.
+    /// </summary>
+    public string? Authority { get; set; }
+
     /// <summary>
     /// The address of the token endpoint
     /// </summary>

--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementServiceCollectionExtensions.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenManagementServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using Duende.AccessTokenManagement;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -38,6 +39,7 @@ public static class ClientCredentialsTokenManagementServiceCollectionExtensions
     public static ClientCredentialsTokenManagementBuilder AddClientCredentialsTokenManagement(this IServiceCollection services)
     {
         services.TryAddSingleton<ITokenRequestSynchronization, TokenRequestSynchronization>();
+        services.TryAddSingleton<ITokenEndpointRetriever, TokenEndpointRetriever>();
 
         services.TryAddTransient<IClientCredentialsTokenManagementService, ClientCredentialsTokenManagementService>();
         services.TryAddTransient<IClientCredentialsTokenCache, DistributedClientCredentialsTokenCache>();

--- a/src/Duende.AccessTokenManagement/Interfaces/ITokenEndpointRetriever.cs
+++ b/src/Duende.AccessTokenManagement/Interfaces/ITokenEndpointRetriever.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace Duende.AccessTokenManagement;
+
+/// <summary>
+/// Retrieves the token endpoint either using discovery or static configuration
+/// </summary>
+public interface ITokenEndpointRetriever
+{
+    /// <summary>
+    /// Gets the token endpoint
+    /// </summary>
+    Task<string> GetAsync(ClientCredentialsClient client);
+}

--- a/src/Duende.AccessTokenManagement/StringExtensions.cs
+++ b/src/Duende.AccessTokenManagement/StringExtensions.cs
@@ -4,10 +4,10 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Duende.AccessTokenManagement.OpenIdConnect;
+namespace Duende.AccessTokenManagement;
 
-// Note that this is duplicated in Duende.AccessTokenManagement, but we can't
-// share the code because it is internal.
+// Note that this is duplicated in Duende.AccessTokenManagement.OpenIdConnect,
+// but we can't share the code because it is internal.
 internal static class StringExtensions
 {
     [DebuggerStepThrough]

--- a/src/Duende.AccessTokenManagement/TokenEndpointRetriever.cs
+++ b/src/Duende.AccessTokenManagement/TokenEndpointRetriever.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using IdentityModel.Client;
+
+namespace Duende.AccessTokenManagement;
+
+/// <inheritdoc/>
+public class TokenEndpointRetriever : ITokenEndpointRetriever
+{
+    private readonly Dictionary<string, DiscoveryCache> _caches = new();
+
+    private DiscoveryCache GetDiscoCache(string authority)
+    {
+        if (!_caches.ContainsKey(authority))
+        {
+            _caches[authority] = new DiscoveryCache(authority);
+        }
+        return _caches[authority];
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> GetAsync(ClientCredentialsClient client)
+    {
+        if (client.Authority.IsPresent())
+        {
+            var discoCache = GetDiscoCache(client.Authority);
+            var disco = await discoCache.GetAsync();
+            if(disco.IsError)
+            {
+                throw new InvalidOperationException("Failed to retrieve disco");
+            }
+            return disco.TokenEndpoint ?? throw new InvalidOperationException("Disco does not contain token endpoint");
+        }
+        else if (client.TokenEndpoint.IsPresent())
+        {
+            return client.TokenEndpoint;
+        }
+        else
+        {
+            throw new InvalidOperationException("No token endpoint or authority configured");
+        }
+
+    }
+}

--- a/test/Tests/Framework/AppHost.cs
+++ b/test/Tests/Framework/AppHost.cs
@@ -107,6 +107,7 @@ public class AppHost : GenericHost
             }
         });
 
+        services.AddSingleton<ITokenEndpointRetriever>(new TestTokenEndpointRetriever(_identityServerHost.Url("/connect/token")));
     }
 
     private void Configure(IApplicationBuilder app)

--- a/test/Tests/Framework/TestTokenEndpointRetreiver.cs
+++ b/test/Tests/Framework/TestTokenEndpointRetreiver.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.AccessTokenManagement.Tests;
+
+public class TestTokenEndpointRetriever(string tokenEndpoint = "https://identityserver/connect/token") : ITokenEndpointRetriever
+{
+    public Task<string> GetAsync(ClientCredentialsClient client)
+    {
+        return Task.FromResult(tokenEndpoint);
+    }
+}


### PR DESCRIPTION
Adds a new authority option. If it is set, we use it to retrieve the discovery document, and use that to configure the token endpoint. Because this is an async operation, we have a new abstraction for retrieval of the token endpoint

Closes DuendeSoftware/foss#49