### PR TITLE
Remove unknown client error message

### DIFF
--- a/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
+++ b/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
@@ -58,21 +58,10 @@ public class ClientCredentialsTokenEndpointService : IClientCredentialsTokenEndp
     {
         var client = _options.Get(clientName);
 
-        var clientIdMissing = string.IsNullOrWhiteSpace(client.ClientId);
-        var tokenEndpointMissing = string.IsNullOrWhiteSpace(client.TokenEndpoint);
-
-        // If both are missing, we infer that this client is just not set up at all
-        if (clientIdMissing && tokenEndpointMissing) 
-        {
-            throw new InvalidOperationException($"Unknown client {clientName}");
-        }
-
-        // Otherwise, if we don't have a specific value that is required, throw an appropriate exception
         if (string.IsNullOrWhiteSpace(client.ClientId))
         {
             throw new InvalidOperationException($"No ClientId configured for client {clientName}");
         }
-
         if (string.IsNullOrWhiteSpace(client.TokenEndpoint))
         {
             throw new InvalidOperationException($"No TokenEndpoint configured for client {clientName}");

--- a/test/Tests/ClientTokenManagementTests.cs
+++ b/test/Tests/ClientTokenManagementTests.cs
@@ -27,7 +27,7 @@ public class ClientTokenManagementTests
         var action = async () => await sut.GetAccessTokenAsync("unknown");
 
         (await Should.ThrowAsync<InvalidOperationException>(action))
-            .Message.ShouldBe("Unknown client unknown");
+            .Message.ShouldBe("No ClientId configured for client unknown");
     }
 
     [Fact]


### PR DESCRIPTION
The "unknown client" error message is sometimes confusing, because we're trying to infer that a client hasn't been configured by the absence of properties of that client. That isn't always true. We have new specific error messages that say both which property of the client we don't have and for which client, so let's just throw one of those errors instead.

@kallayj would this cover your use cases?